### PR TITLE
fix imports so dependent packages do not break

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 	"github.com/nats-io/nuid"
 )
 

--- a/bench/benchlib_test.go
+++ b/bench/benchlib_test.go
@@ -2,7 +2,7 @@ package bench
 
 import (
 	"fmt"
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 	"strings"
 	"testing"
 	"time"


### PR DESCRIPTION
Must fix this in order for `stan-bench` to work.