### PR TITLE
Add FlusherTimeout to prevent blocking for long on unhealthy connections

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -60,6 +60,7 @@ var (
 	ErrSlowConsumer         = errors.New("nats: slow consumer, messages dropped")
 	ErrTimeout              = errors.New("nats: timeout")
 	ErrBadTimeout           = errors.New("nats: timeout invalid")
+	ErrFlusherTimeout       = errors.New("nats: flusher timeout")
 	ErrAuthorization        = errors.New("nats: authorization violation")
 	ErrNoServers            = errors.New("nats: no servers available for connection")
 	ErrJsonParse            = errors.New("nats: connect message, json parse error")
@@ -129,6 +130,11 @@ type Options struct {
 	MaxReconnect   int
 	ReconnectWait  time.Duration
 	Timeout        time.Duration
+
+	// FlusherTimeout is the maximum time to wait for the flusher loop
+	// to be able to finish writing to the underlying socket.
+	FlusherTimeout time.Duration
+
 	PingInterval   time.Duration // disabled if 0 or negative
 	MaxPingsOut    int
 	ClosedCB       ConnHandler
@@ -1580,6 +1586,7 @@ func (nc *Conn) flusher() {
 	bw := nc.bw
 	conn := nc.conn
 	fch := nc.fch
+	flusherTimeout := nc.Opts.FlusherTimeout
 	nc.mu.Unlock()
 
 	if conn == nil || bw == nil {
@@ -1598,6 +1605,12 @@ func (nc *Conn) flusher() {
 			return
 		}
 		if bw.Buffered() > 0 {
+			// Allow customizing how long we should wait for a flush to be done
+			// to prevent unhealthy connections blocking the client for too long.
+			if flusherTimeout > 0 {
+				conn.SetWriteDeadline(time.Now().Add(flusherTimeout))
+			}
+
 			if err := bw.Flush(); err != nil {
 				if nc.err == nil {
 					nc.err = err
@@ -1806,7 +1819,6 @@ func (nc *Conn) publish(subj, reply string, data []byte) error {
 	msgh = append(msgh, b[i:]...)
 	msgh = append(msgh, _CRLF_...)
 
-	// FIXME, do deadlines here
 	_, err := nc.bw.Write(msgh)
 	if err == nil {
 		_, err = nc.bw.Write(data)

--- a/nats.go
+++ b/nats.go
@@ -60,7 +60,6 @@ var (
 	ErrSlowConsumer         = errors.New("nats: slow consumer, messages dropped")
 	ErrTimeout              = errors.New("nats: timeout")
 	ErrBadTimeout           = errors.New("nats: timeout invalid")
-	ErrFlusherTimeout       = errors.New("nats: flusher timeout")
 	ErrAuthorization        = errors.New("nats: authorization violation")
 	ErrNoServers            = errors.New("nats: no servers available for connection")
 	ErrJsonParse            = errors.New("nats: connect message, json parse error")
@@ -1616,6 +1615,7 @@ func (nc *Conn) flusher() {
 					nc.err = err
 				}
 			}
+			conn.SetWriteDeadline(time.Time{})
 		}
 		nc.mu.Unlock()
 	}

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1340,7 +1340,7 @@ func TestCustomFlusherTimeout(t *testing.T) {
 		Servers: []string{nats.DefaultURL},
 
 		// Use short flusher timeout to trigger the error
-		FlusherTimeout: 1 * time.Millisecond,
+		FlusherTimeout: 1 * time.Microsecond,
 
 		// Upon failure to be able to exercice ping pong interval
 		// then we will hit this timeout and disconnect

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1295,3 +1295,87 @@ func TestUseCustomDialer(t *testing.T) {
 		t.Fatalf("Expected DialTimeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Dialer.Timeout)
 	}
 }
+
+func TestCustomFlusherTimeout(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	opts := &nats.Options{
+		Servers: []string{nats.DefaultURL},
+
+		// Reasonably large flusher timeout will not induce errors
+		// when we can flush fast
+		FlusherTimeout: 10 * time.Second,
+	}
+	nc1, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Expected to be able to connect, got: %s", err)
+	}
+	doneCh := make(chan struct{}, 0)
+	payload := ""
+	for i := 0; i < 8192; i++ {
+		payload += "A"
+	}
+	payloadBytes := []byte(payload)
+
+	go func() {
+		for {
+			select {
+			case <-time.After(200 * time.Millisecond):
+				err := nc1.Publish("hello", payloadBytes)
+				if err != nil {
+					t.Errorf("Error during publish: %s", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Errorf("Timeout publishing messages")
+				return
+			case <-doneCh:
+				return
+			}
+		}
+	}()
+	defer nc1.Close()
+
+	opts = &nats.Options{
+		Servers: []string{nats.DefaultURL},
+
+		// Use short flusher timeout to trigger the error
+		FlusherTimeout: 1 * time.Millisecond,
+
+		// Upon failure to be able to exercice ping pong interval
+		// then we will hit this timeout and disconnect
+		PingInterval: 500 * time.Millisecond,
+	}
+
+	opts.DisconnectedCB = func(nc *nats.Conn) {
+		// Ping loops that test is done
+		doneCh <- struct{}{}
+	}
+
+	nc2, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Expected to be able to connect, got: %s", err)
+	}
+	defer nc2.Close()
+
+	// Consume messages to make the reading loop work
+	_, err = nc2.Subscribe(">", func(_ *nats.Msg) {})
+	if err != nil {
+		t.Fatalf("Expected to be able to create subscription, got: %s", err)
+	}
+
+	for {
+		select {
+		case <-time.After(100 * time.Millisecond):
+			// Some of the publishes will succeed and others fail with i/o timeout error
+			// but eventually ping interval will fail and close the connection.
+			err = nc2.Publish("world", payloadBytes)
+			if err == nats.ErrConnectionClosed {
+				return
+			}
+		case <-time.After(5 * time.Second):
+			t.Errorf("Timeout publishing messages")
+			return
+		}
+	}
+}


### PR DESCRIPTION
This adds a customizable `FlusherTimeout` option for the flusher loop to be able to yield after a certain time in case a write to the underlying writer takes too long due to an unhealthy connection.

This prevents the client blocking for an indefinite amount of time until reaching an OS level `i/o timeout` since the `bufio.Flush` is happening while the lock is being hold, thus giving room for the ping interval to be able to `processOpErr` and disconnect once it reaches the max amount of missing ping replies from the server (with an unhealthy connection the reading loop would be stuck on `conn.Read` too because there is no deadline either, so it would take as a long as the ping interval check closes the connection or `i/o timeout`).
