### PR TITLE
Update go versions to *.4. Update staticcheck URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 sudo: false
 go:
-- 1.6.3
-- 1.7.3
+- 1.6.4
+- 1.7.4
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-- go get honnef.co/go/staticcheck/cmd/staticcheck
+- go get honnef.co/go/tools/cmd/staticcheck
 script:
 - go fmt ./...
 - go vet ./...


### PR DESCRIPTION
The `staticcheck` tool has a new home. [Details here](https://www.reddit.com/r/golang/comments/5pzsmu/dominikh_static_analysis_tools_staticcheck/?st=iycfcrrk&sh=4928b9c1).
I also bumped up the go versions to 1.6.4 and 1.7.4.