### PR TITLE
Add gosimple, update staticcheck and go to .4 releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: go
 sudo: false
 go:
-- 1.6.3
-- 1.7.3
+- 1.6.4
+- 1.7.4
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-- go get honnef.co/go/staticcheck/cmd/staticcheck
-script:
+- go get honnef.co/go/tools/cmd/staticcheck
+- go get honnef.co/go/tools/cmd/gosimple
+before_script:
 - go fmt ./...
 - go vet ./...
+- gosimple ./...
+- staticcheck -ignore "$(cat staticcheck.ignore)" ./...
+script:
 - go test -i -race ./...
 - go test -v -race ./...
-- staticcheck -ignore="github.com/nats-io/go-nats/*_test.go:SA2002 github.com/nats-io/go-nats/*/*_test.go:SA2002" ./...
 after_script:
 - if [ "$TRAVIS_GO_VERSION" = "1.7.3" ]; then ./scripts/cov.sh; fi

--- a/encoders/protobuf/protobuf_enc.go
+++ b/encoders/protobuf/protobuf_enc.go
@@ -58,9 +58,5 @@ func (pb *ProtobufEncoder) Decode(subject string, data []byte, vPtr interface{})
 		return ErrInvalidProtoMsgDecode
 	}
 
-	err := proto.Unmarshal(data, i)
-	if err != nil {
-		return err
-	}
-	return nil
+	return proto.Unmarshal(data, i)
 }

--- a/nats.go
+++ b/nats.go
@@ -1011,12 +1011,7 @@ func (nc *Conn) processExpectedInfo() error {
 		return err
 	}
 
-	err = nc.checkForSecure()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return nc.checkForSecure()
 }
 
 // Sends a protocol control message by queuing into the bufio writer

--- a/staticcheck.ignore
+++ b/staticcheck.ignore
@@ -1,0 +1,2 @@
+github.com/nats-io/go-nats/*_test.go:SA2002
+github.com/nats-io/go-nats/*/*_test.go:SA2002

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -287,12 +287,13 @@ func TestServerTLSHintConnections(t *testing.T) {
 
 	nc, err := nats.Connect(secureURL, nats.RootCAs("./configs/certs/badca.pem"))
 	if err == nil {
+		nc.Close()
 		t.Fatal("Expected an error from bad RootCA file")
 	}
 
 	nc, err = nats.Connect(secureURL, nats.RootCAs("./configs/certs/ca.pem"))
 	if err != nil {
-		t.Fatal("Failed to create secure (TLS) connection", err)
+		t.Fatalf("Failed to create secure (TLS) connection: %v", err)
 	}
 	defer nc.Close()
 }

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -371,6 +371,9 @@ func TestIsValidSubscriber(t *testing.T) {
 	defer nc.Close()
 
 	sub, err := nc.SubscribeSync("foo")
+	if err != nil {
+		t.Fatalf("Error on subscribe: %v", err)
+	}
 	if !sub.IsValid() {
 		t.Fatalf("Subscription should be valid")
 	}


### PR DESCRIPTION
Added gosimple + update to staticcheck

Based on @y0ssar1an PRs.

- Update go versions to .4
- Get gosimple package
- Updated staticcheck's URL
- Use staticcheck.ignore file for exceptions
- Moved build and staticcheck/gosimple checks in `before_script`
  section to fail fast
- Fixed reports from gosimple and staticcheck