### PR TITLE
add ServerLocation() api for server details

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -101,6 +101,13 @@ const (
 	CONNECTING
 )
 
+// NetDialer abstracts the net.Dialer.Dial(network, address)
+// operation, allowing pre-authorized connections like
+// the gnatsd/health.Icc structure for internal clients.
+type NetDialer interface {
+	Dial(network, address string) (net.Conn, error)
+}
+
 // ConnHandler is used for asynchronous events such as
 // disconnected and closed connections.
 type ConnHandler func(*Conn)
@@ -156,7 +163,7 @@ type Options struct {
 	Token    string
 
 	// Dialer allows users setting a custom Dialer
-	Dialer *net.Dialer
+	Dialer NetDialer
 }
 
 const (
@@ -287,6 +294,7 @@ type serverInfo struct {
 	TLSRequired  bool     `json:"tls_required"`
 	MaxPayload   int64    `json:"max_payload"`
 	ConnectURLs  []string `json:"connect_urls,omitempty"`
+	Rank         int      `json:"health_rank"`
 }
 
 const (
@@ -495,7 +503,7 @@ func Token(token string) Option {
 
 // Dialer is an Option to set the dialer which will be used when
 // attempting to establish a connection.
-func Dialer(dialer *net.Dialer) Option {
+func Dialer(dialer NetDialer) Option {
 	return func(o *Options) error {
 		o.Dialer = dialer
 		return nil
@@ -2640,4 +2648,84 @@ func (nc *Conn) TLSRequired() bool {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
 	return nc.info.TLSRequired
+}
+
+// ServerLocation() reports
+// the connected server's details
+// in a ServerLoc structure
+// allocated for this call.
+//
+// The return value will be (nil, ErrInvalidConnection)
+// if we are not connected.
+//
+// Atomic (consistent) access
+// to the combination of these
+// settings is needed by
+// the health agent.
+func (nc *Conn) ServerLocation() (*ServerLoc, error) {
+
+	if nc == nil {
+		return nil, ErrInvalidConnection
+	}
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+
+	if nc.status != CONNECTED {
+		return nil, ErrInvalidConnection
+	}
+
+	sloc := &ServerLoc{
+		ID:   nc.info.Id,
+		Rank: nc.info.Rank,
+	}
+
+	host, sport, err := net.SplitHostPort(
+		nc.conn.RemoteAddr().String(),
+	)
+	if err != nil {
+		return sloc, err
+	}
+	sloc.Host = host
+
+	port, err := strconv.Atoi(sport)
+	if err != nil {
+		return sloc, err
+	}
+	sloc.Port = port
+
+	return sloc, nil
+}
+
+// ServerLoc atomically provides
+// server identity, location, and rank.
+// It is used by the health-agent.
+type ServerLoc struct {
+	ID   string `json:"serverId"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+
+	// Are we the leader?
+	IsLeader bool `json:"leader"`
+
+	// LeaseExpires is zero for any
+	// non-leader. For the leader,
+	// LeaseExpires tells you when
+	// the leaders lease expires.
+	LeaseExpires time.Time `json:"leaseExpires"`
+
+	// lower rank is leader until lease
+	// expires. Ties are broken by ID.
+	// Rank should be assignable on the
+	// gnatsd command line with -rank to
+	// let the operator prioritize
+	// leadership for certain hosts.
+	Rank int `json:"rank"`
+}
+
+func (s *ServerLoc) String() string {
+	by, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(by)
 }

--- a/nats_test.go
+++ b/nats_test.go
@@ -1146,3 +1146,39 @@ func TestConnServers(t *testing.T) {
 
 	validateURLs(c.Servers(), "nats://localhost:4333", "nats://localhost:4444")
 }
+
+////// ServerLocation test
+
+func TestServerLocation(t *testing.T) {
+	ts := RunServerOnPort(TEST_PORT)
+	defer ts.Shutdown()
+
+	opts := reconnectOpts
+	nc, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("nc.Connect() unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	sloc, err := nc.ServerLocation()
+	if err != nil {
+		t.Fatalf("nc.ServerLocation() unexpected error: %v", err)
+	}
+	if sloc.ID == "" {
+		t.Fatalf("nc.ServerLocation() returned bad ID")
+	}
+	if sloc.Port != TEST_PORT {
+		t.Fatalf("nc.ServerLocation() returned bad Port")
+	}
+	if sloc.Host == "" {
+		t.Fatalf("nc.ServerLocation() failed to supply Host")
+	}
+	if sloc.Rank != 0 {
+		t.Fatalf("nc.ServerLocation() default "+
+			"rank of 0 expected; instead: %v", sloc.Rank)
+	}
+	str := sloc.String()
+	if str[0] != '{' {
+		t.Fatalf("String() method for ServerLoc did not give JSON.")
+	}
+}

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1282,7 +1282,7 @@ func TestUseCustomDialer(t *testing.T) {
 		t.Fatalf("Unexpected error on connect: %v", err)
 	}
 	defer nc2.Close()
-	if !nc2.Opts.Dialer.DualStack {
+	if !nc2.Opts.Dialer.(*net.Dialer).DualStack {
 		t.Fatalf("Expected for dialer to be customized to use dual stack support")
 	}
 
@@ -1292,8 +1292,8 @@ func TestUseCustomDialer(t *testing.T) {
 		t.Fatalf("Unexpected error on connect: %v", err)
 	}
 	defer nc3.Close()
-	if nc3.Opts.Dialer.Timeout != nats.DefaultTimeout {
-		t.Fatalf("Expected DialTimeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Dialer.Timeout)
+	if nc3.Opts.Dialer.(*net.Dialer).Timeout != nats.DefaultTimeout {
+		t.Fatalf("Expected DialTimeout to be set to %v, got %v", nats.DefaultTimeout, nc.Opts.Dialer.(*net.Dialer).Timeout)
 	}
 }
 


### PR DESCRIPTION
Add ServerLocation() api for server details; 
the client needs to fetch a set of information atomically for correctness.

Generalize *net.Dialer to NetDialer interface so that pre-authorized internal clients can be brought up.

Update: this is a small pull request with a couple of minor tweaks needed for the health monitoring PR to build, see https://github.com/nats-io/gnatsd/pull/435 for that.