### PR TITLE
[FIXED] Possible panic on WaitGroup.Wait()

### DIFF
--- a/staticcheck.ignore
+++ b/staticcheck.ignore
@@ -1,2 +1,3 @@
 github.com/nats-io/go-nats/*_test.go:SA2002
 github.com/nats-io/go-nats/*/*_test.go:SA2002
+github.com/nats-io/go-nats/nats.go:SA6000


### PR DESCRIPTION
There have been 2 reports in the last 10 months of this happening
once each. We have not been able to reproduce the issue. However,
this code change should eliminate the possibility of code going
into a Wait() while in parallel doing an Add() (for the same group).
There is no new test since we have multiple tests that check for
reconnect and we have not been able to reproduce. A long running
test causing 100,000 server restarts at random interval has been
running on *original code* without producing the panic.

Attempt to resolve #192