### PR TITLE
Fix data race in cluster test

### DIFF
--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -463,12 +463,14 @@ func TestProperFalloutAfterMaxAttemptsWithAuthMismatch(t *testing.T) {
 
 	// Wait for ClosedCB
 	if e := WaitTime(cch, 5*time.Second); e != nil {
-		t.Fatalf("Did not receive a closed callback message, #reconnects: %v", nc.Reconnects)
+		reconnects := nc.Stats().Reconnects
+		t.Fatalf("Did not receive a closed callback message, #reconnects: %v", reconnects)
 	}
 
 	// Make sure we have not exceeded MaxReconnect
-	if nc.Reconnects != uint64(opts.MaxReconnect) {
-		t.Fatalf("Num reconnects was %v, expected %v", nc.Reconnects, opts.MaxReconnect)
+	reconnects := nc.Stats().Reconnects
+	if reconnects != uint64(opts.MaxReconnect) {
+		t.Fatalf("Num reconnects was %v, expected %v", reconnects, opts.MaxReconnect)
 	}
 
 	// Make sure we are not still reconnecting..

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -617,7 +617,7 @@ func TestReconnectBufSize(t *testing.T) {
 
 	// This should fail since we have exhausted the backing buffer.
 	if err := nc.Publish("foo", msg); err == nil {
-		//		t.Fatalf("Expected to fail to publish message: got no error\n")
+		t.Fatalf("Expected to fail to publish message: got no error\n")
 	}
 	nc.Buffered()
 }


### PR DESCRIPTION
Fixes race which occurs in one of the tests

```
=== RUN   TestProperFalloutAfterMaxAttemptsWithAuthMismatch
==================
WARNING: DATA RACE
Read at 0x00c420302da8 by goroutine 55:
  runtime.convT2E()
      /usr/local/go/src/runtime/iface.go:191 +0x0
  github.com/nats-io/go-nats/test.TestProperFalloutAfterMaxAttemptsWithAuthMismatch()
      /Users/wally/repos/nats-dev/src/github.com/nats-io/go-nats/test/cluster_test.go:465 +0x96b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:657 +0x107

Previous write at 0x00c420302da8 by goroutine 54:
  github.com/nats-io/go-nats.(*Conn).doReconnect()
      /Users/wally/repos/nats-dev/src/github.com/nats-io/go-nats/nats.go:1311 +0x3da

Goroutine 55 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:697 +0x543
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:882 +0xaa
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:657 +0x107
  testing.runTests()
      /usr/local/go/src/testing/testing.go:888 +0x4e0
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:822 +0x1c3
  main.main()
      github.com/nats-io/go-nats/test/_test/_testmain.go:288 +0x20f

Goroutine 54 (running) created at:
  github.com/nats-io/go-nats.(*Conn).processOpErr()
      /Users/wally/repos/nats-dev/src/github.com/nats-io/go-nats/nats.go:1390 +0x53b
  github.com/nats-io/go-nats.(*Conn).readLoop()
      /Users/wally/repos/nats-dev/src/github.com/nats-io/go-nats/nats.go:1463 +0x327

```
