### PR TITLE
wip: Adding Context aware APIs to the client

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,60 @@
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
+
+// +build go1.7
+
+// A Go client for the NATS messaging system (https://nats.io).
+package nats
+
+import "context"
+
+// RequestWithContext takes a context, a subject and payload in bytes
+// and request expecting a single response.
+func (nc *Conn) RequestWithContext(
+	ctx context.Context,
+	subj string,
+	data []byte,
+) (*Msg, error) {
+	inbox := NewInbox()
+	ch := make(chan *Msg, RequestChanLen)
+	recvCh := make(chan *Msg, 1)
+	var recvMsg *Msg
+
+	s, err := nc.subscribe(inbox, _EMPTY_, func(msg *Msg) {
+		recvCh <- msg
+	}, ch)
+	if err != nil {
+		// If we errored here but context has been canceled
+		// then still return the error from context.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		return nil, err
+	}
+	s.AutoUnsubscribe(1)
+	defer s.Unsubscribe()
+	defer close(ch)
+
+	err = nc.PublishRequest(subj, inbox, data)
+	if err != nil {
+		// Still prefer error from context
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		// Context has been canceled so return opaque error
+		return nil, ctx.Err()
+	case recvMsg = <-recvCh:
+		break
+	}
+	return recvMsg, nil
+}

--- a/context.go
+++ b/context.go
@@ -71,10 +71,9 @@ func (s *Subscription) SetContext(ctx context.Context) {
 // to a synchronous subscriber or block until one is available until context
 // gets canceled.
 func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
-	s.SetContext(ctx)
-
 	// Call NextMsg from subscription but disabling the timeout
 	// as we rely on the context for the cancellation instead.
+	s.SetContext(ctx)
 	msg, err := s.NextMsg(0)
 	if err != nil {
 		// Also prefer error from context in case it has occurred.

--- a/nats.go
+++ b/nats.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 // A Go client for the NATS messaging system (https://nats.io).
 package nats

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -1,0 +1,253 @@
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
+
+// +build go1.7
+
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/go-nats"
+)
+
+func TestRequestWithTimeoutContext(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// Simulates latency into the client so that timeout is hit.
+		time.Sleep(200 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("NG"))
+	})
+	nc.Subscribe("fast", func(m *nats.Msg) {
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	ctx, cancelCB := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	// Fast request should not fail at this point.
+	resp, err := nc.RequestWithContext(ctx, "fast", []byte(""))
+	if err != nil {
+		t.Fatalf("Expected request with context to not fail on fast response: %s", err)
+	}
+	got := string(resp.Data)
+	expected := "OK"
+	if got != expected {
+		t.Errorf("Expected to receive %s, got: %s", expected, got)
+	}
+
+	// Slow request hits timeout so expected to fail.
+	_, err = nc.RequestWithContext(ctx, "slow", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with timeout context to fail: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected = `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+
+	// 2nd request should fail again even if they would be fast because context
+	// has already timed out.
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with context to fail: %s", err)
+	}
+}
+
+func TestRequestWithTimeoutContextCancelled(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	nc.Subscribe("fast", func(m *nats.Msg) {
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	ctx, cancelCB := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelCB()
+
+	// Fast request should not fail
+	resp, err := nc.RequestWithContext(ctx, "fast", []byte(""))
+	if err != nil {
+		t.Fatalf("Expected request with context to not fail on fast response: %s", err)
+	}
+	got := string(resp.Data)
+	expected := "OK"
+	if got != expected {
+		t.Errorf("Expected to receive %s, got: %s", expected, got)
+	}
+
+	// Cancel the context already so that rest of requests fail.
+	cancelCB()
+
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with timeout context to fail: %s", err)
+	}
+
+	// Reported error is "context canceled" from Context package,
+	// which is not a timeout error.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	if _, ok := err.(timeoutError); ok {
+		t.Errorf("Expected to not have a timeout error")
+	}
+	expected = `context canceled`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+
+	// 2nd request should fail again even if fast because context has already been canceled
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with context to fail: %s", err)
+	}
+}
+
+func TestRequestWithCancelContext(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	ctx, cancelCB := context.WithCancel(context.Background())
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	// timer which cancels the context though can also be arbitrarily extended
+	expirationTimer := time.AfterFunc(100*time.Millisecond, func() {
+		cancelCB()
+	})
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// simulates latency into the client so that timeout is hit.
+		time.Sleep(40 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+	nc.Subscribe("slower", func(m *nats.Msg) {
+		// we know this request will take longer so extend the timeout
+		expirationTimer.Reset(100 * time.Millisecond)
+
+		// slower reply which would have hit original timeout
+		time.Sleep(90 * time.Millisecond)
+
+		nc.Publish(m.Reply, []byte("Also OK"))
+	})
+
+	for i := 0; i < 2; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// A third request with latency would make the context
+	// get cancelled, but these reset the timer so deadline
+	// gets extended:
+	for i := 0; i < 10; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slower", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "Also OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// One more slow request will expire the timer and cause an error...
+	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+	if err == nil {
+		t.Fatalf("Expected request with cancellation context to fail: %s", err)
+	}
+
+	// ...though reported error is "context canceled" from Context package,
+	// which is not a timeout error.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	if _, ok := err.(timeoutError); ok {
+		t.Errorf("Expected to not have a timeout error")
+	}
+	expected := `context canceled`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}
+
+func TestRequestWithDeadlineContext(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	ctx, cancelCB := context.WithDeadline(context.Background(), deadline)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// simulates latency into the client so that timeout is hit.
+		time.Sleep(40 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	for i := 0; i < 2; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// A third request with latency would make the context
+	// reach the deadline.
+	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+	if err == nil {
+		t.Fatalf("Expected request with context to reach deadline: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error Timeout interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected := `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -265,8 +265,9 @@ func TestSubNextMsgWithDeadlineContext(t *testing.T) {
 
 	sub, err := nc.SubscribeSync("slow")
 	if err != nil {
-
+		t.Fatalf("Expected to be able to subscribe: %s", err)
 	}
+
 	for i := 0; i < 2; i++ {
 		err := nc.Publish("slow", []byte("OK"))
 		if err != nil {


### PR DESCRIPTION
This follows from the idea by @colinsullivan1 at https://github.com/nats-io/go-nats/issues/221#issuecomment-288129861 and needs another pass but opening wip PR already for early comments.

Currently it supports the following 2 APIs (plus an extra one):

```
func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte) (*Msg, error)
func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error)
+ func (s *Subscription) SetContext(ctx context.Context)
```

Since `"context"` package is supported only after Go1.7, I added a `+build go1.7` tag just in case so that it does not break if using older versions of the runtime plus a small `cntxt` interface as part of the `Subscription` state which also implements `Context` interface, this way in those clients it just does not get used unless using more recent versions of Go.
