### PR TITLE
[ADDED] context.Context support

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,175 @@
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
+
+// +build go1.7
+
+// A Go client for the NATS messaging system (https://nats.io).
+package nats
+
+import (
+	"context"
+	"reflect"
+)
+
+// RequestWithContext takes a context, a subject and payload
+// in bytes and request expecting a single response.
+func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte) (*Msg, error) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	inbox := NewInbox()
+	ch := make(chan *Msg, RequestChanLen)
+
+	s, err := nc.subscribe(inbox, _EMPTY_, nil, ch)
+	if err != nil {
+		// If we errored here but context has been canceled already
+		// then return the error from the context instead.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		return nil, err
+	}
+	s.AutoUnsubscribe(1)
+	defer s.Unsubscribe()
+
+	err = nc.PublishRequest(subj, inbox, data)
+	if err != nil {
+		// Use error from context instead if already canceled.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		return nil, err
+	}
+
+	return s.NextMsgWithContext(ctx)
+}
+
+// NextMsgWithContext takes a context and returns the next message available
+// to a synchronous subscriber, blocking until either one is available or
+// context gets canceled.
+func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
+	if ctx == nil {
+		panic("nil context")
+	}
+	if s == nil {
+		return nil, ErrBadSubscription
+	}
+
+	// Add validateNextMsgState func and reuse
+	s.mu.Lock()
+	if s.connClosed {
+		s.mu.Unlock()
+		return nil, ErrConnectionClosed
+	}
+	if s.mch == nil {
+		if s.max > 0 && s.delivered >= s.max {
+			s.mu.Unlock()
+			return nil, ErrMaxMessages
+		} else if s.closed {
+			s.mu.Unlock()
+			return nil, ErrBadSubscription
+		}
+	}
+	if s.mcb != nil {
+		s.mu.Unlock()
+		return nil, ErrSyncSubRequired
+	}
+	if s.sc {
+		s.sc = false
+		s.mu.Unlock()
+		return nil, ErrSlowConsumer
+	}
+
+	// snapshot
+	nc := s.conn
+	mch := s.mch
+	max := s.max
+	s.mu.Unlock()
+
+	var ok bool
+	var msg *Msg
+
+	select {
+	case msg, ok = <-mch:
+		if !ok {
+			return nil, ErrConnectionClosed
+		}
+		// Update some stats.
+		s.mu.Lock()
+		s.delivered++
+		delivered := s.delivered
+		if s.typ == SyncSubscription {
+			s.pMsgs--
+			s.pBytes -= len(msg.Data)
+		}
+		s.mu.Unlock()
+
+		if max > 0 {
+			if delivered > max {
+				return nil, ErrMaxMessages
+			}
+			// Remove subscription if we have reached max.
+			if delivered == max {
+				nc.mu.Lock()
+				nc.removeSub(s)
+				nc.mu.Unlock()
+			}
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return msg, nil
+}
+
+// RequestWithContext will create an Inbox and perform a Request
+// using the provided cancellation context with the Inbox reply
+// for the data v. A response will be decoded into the vPtrResponse.
+func (c *EncodedConn) RequestWithContext(
+	ctx context.Context,
+	subject string,
+	v interface{},
+	vPtr interface{},
+) error {
+	if ctx == nil {
+		panic("nil context")
+	}
+	b, err := c.Enc.Encode(subject, v)
+	if err != nil {
+		// Use error from context instead if already canceled.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		return err
+	}
+	m, err := c.Conn.RequestWithContext(ctx, subject, b)
+	if err != nil {
+		return err
+	}
+	if reflect.TypeOf(vPtr) == emptyMsgType {
+		mPtr := vPtr.(*Msg)
+		*mPtr = *m
+	} else {
+		err = c.Enc.Decode(m.Subject, m.Data, vPtr)
+		if err != nil {
+			// Use error from context instead if already canceled.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/context.go
+++ b/context.go
@@ -13,6 +13,10 @@ import (
 // RequestWithContext takes a context, a subject and payload
 // in bytes and request expecting a single response.
 func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte) (*Msg, error) {
+	if ctx == nil {
+		return nil, ErrInvalidContext
+	}
+
 	inbox := NewInbox()
 	ch := make(chan *Msg, RequestChanLen)
 
@@ -35,6 +39,9 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 // available to a synchronous subscriber, blocking until it is delivered
 // or context gets canceled.
 func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
+	if ctx == nil {
+		return nil, ErrInvalidContext
+	}
 	if s == nil {
 		return nil, ErrBadSubscription
 	}
@@ -73,6 +80,10 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 // using the provided cancellation context with the Inbox reply
 // for the data v. A response will be decoded into the vPtrResponse.
 func (c *EncodedConn) RequestWithContext(ctx context.Context, subject string, v interface{}, vPtr interface{}) error {
+	if ctx == nil {
+		return ErrInvalidContext
+	}
+
 	b, err := c.Enc.Encode(subject, v)
 	if err != nil {
 		return err

--- a/context.go
+++ b/context.go
@@ -13,9 +13,6 @@ import (
 // RequestWithContext takes a context, a subject and payload
 // in bytes and request expecting a single response.
 func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte) (*Msg, error) {
-	if ctx == nil {
-		panic("nil context")
-	}
 	inbox := NewInbox()
 	ch := make(chan *Msg, RequestChanLen)
 
@@ -38,9 +35,6 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 // available to a synchronous subscriber, blocking until it is delivered
 // or context gets canceled.
 func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
-	if ctx == nil {
-		panic("nil context")
-	}
 	if s == nil {
 		return nil, ErrBadSubscription
 	}
@@ -79,9 +73,6 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 // using the provided cancellation context with the Inbox reply
 // for the data v. A response will be decoded into the vPtrResponse.
 func (c *EncodedConn) RequestWithContext(ctx context.Context, subject string, v interface{}, vPtr interface{}) error {
-	if ctx == nil {
-		panic("nil context")
-	}
 	b, err := c.Enc.Encode(subject, v)
 	if err != nil {
 		return err

--- a/context.go
+++ b/context.go
@@ -78,12 +78,7 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 // RequestWithContext will create an Inbox and perform a Request
 // using the provided cancellation context with the Inbox reply
 // for the data v. A response will be decoded into the vPtrResponse.
-func (c *EncodedConn) RequestWithContext(
-	ctx context.Context,
-	subject string,
-	v interface{},
-	vPtr interface{},
-) error {
+func (c *EncodedConn) RequestWithContext(ctx context.Context, subject string, v interface{}, vPtr interface{}) error {
 	if ctx == nil {
 		panic("nil context")
 	}

--- a/nats.go
+++ b/nats.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 Apcera Inc. All rights reserved.
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
 
 // A Go client for the NATS messaging system (https://nats.io).
 package nats

--- a/nats.go
+++ b/nats.go
@@ -72,6 +72,7 @@ var (
 	ErrInvalidConnection    = errors.New("nats: invalid connection")
 	ErrInvalidMsg           = errors.New("nats: invalid message or message nil")
 	ErrInvalidArg           = errors.New("nats: invalid argument")
+	ErrInvalidContext       = errors.New("nats: invalid context")
 	ErrStaleConnection      = errors.New("nats: " + STALE_CONNECTION)
 )
 

--- a/staticcheck.ignore
+++ b/staticcheck.ignore
@@ -1,3 +1,4 @@
 github.com/nats-io/go-nats/*_test.go:SA2002
 github.com/nats-io/go-nats/*/*_test.go:SA2002
+github.com/nats-io/go-nats/test/context_test.go:SA1012
 github.com/nats-io/go-nats/nats.go:SA6000

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -1,0 +1,380 @@
+// Copyright 2012-2017 Apcera Inc. All rights reserved.
+
+// +build go1.7
+
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/go-nats"
+)
+
+func TestContextRequestWithTimeout(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// Simulates latency into the client so that timeout is hit.
+		time.Sleep(200 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("NG"))
+	})
+	nc.Subscribe("fast", func(m *nats.Msg) {
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	ctx, cancelCB := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	// Fast request should not fail at this point.
+	resp, err := nc.RequestWithContext(ctx, "fast", []byte(""))
+	if err != nil {
+		t.Fatalf("Expected request with context to not fail on fast response: %s", err)
+	}
+	got := string(resp.Data)
+	expected := "OK"
+	if got != expected {
+		t.Errorf("Expected to receive %s, got: %s", expected, got)
+	}
+
+	// Slow request hits timeout so expected to fail.
+	_, err = nc.RequestWithContext(ctx, "slow", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with timeout context to fail: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected = `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+
+	// 2nd request should fail again even if they would be fast because context
+	// has already timed out.
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with context to fail: %s", err)
+	}
+}
+
+func TestContextRequestWithTimeoutCancelled(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	nc.Subscribe("fast", func(m *nats.Msg) {
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	ctx, cancelCB := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelCB()
+
+	// Fast request should not fail
+	resp, err := nc.RequestWithContext(ctx, "fast", []byte(""))
+	if err != nil {
+		t.Fatalf("Expected request with context to not fail on fast response: %s", err)
+	}
+	got := string(resp.Data)
+	expected := "OK"
+	if got != expected {
+		t.Errorf("Expected to receive %s, got: %s", expected, got)
+	}
+
+	// Cancel the context already so that rest of requests fail.
+	cancelCB()
+
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with timeout context to fail: %s", err)
+	}
+
+	// Reported error is "context canceled" from Context package,
+	// which is not a timeout error.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	if _, ok := err.(timeoutError); ok {
+		t.Errorf("Expected to not have a timeout error")
+	}
+	expected = `context canceled`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+
+	// 2nd request should fail again even if fast because context has already been canceled
+	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
+	if err == nil {
+		t.Fatalf("Expected request with context to fail: %s", err)
+	}
+}
+
+func TestContextRequestWithCancel(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	ctx, cancelCB := context.WithCancel(context.Background())
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	// timer which cancels the context though can also be arbitrarily extended
+	expirationTimer := time.AfterFunc(100*time.Millisecond, func() {
+		cancelCB()
+	})
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// simulates latency into the client so that timeout is hit.
+		time.Sleep(40 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+	nc.Subscribe("slower", func(m *nats.Msg) {
+		// we know this request will take longer so extend the timeout
+		expirationTimer.Reset(100 * time.Millisecond)
+
+		// slower reply which would have hit original timeout
+		time.Sleep(90 * time.Millisecond)
+
+		nc.Publish(m.Reply, []byte("Also OK"))
+	})
+
+	for i := 0; i < 2; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// A third request with latency would make the context
+	// get cancelled, but these reset the timer so deadline
+	// gets extended:
+	for i := 0; i < 10; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slower", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "Also OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// One more slow request will expire the timer and cause an error...
+	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+	if err == nil {
+		t.Fatalf("Expected request with cancellation context to fail: %s", err)
+	}
+
+	// ...though reported error is "context canceled" from Context package,
+	// which is not a timeout error.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	if _, ok := err.(timeoutError); ok {
+		t.Errorf("Expected to not have a timeout error")
+	}
+	expected := `context canceled`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}
+
+func TestContextRequestWithDeadline(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	ctx, cancelCB := context.WithDeadline(context.Background(), deadline)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	nc.Subscribe("slow", func(m *nats.Msg) {
+		// simulates latency into the client so that timeout is hit.
+		time.Sleep(40 * time.Millisecond)
+		nc.Publish(m.Reply, []byte("OK"))
+	})
+
+	for i := 0; i < 2; i++ {
+		resp, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+		if err != nil {
+			t.Fatalf("Expected request with context to not fail: %s", err)
+		}
+		got := string(resp.Data)
+		expected := "OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// A third request with latency would make the context
+	// reach the deadline.
+	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
+	if err == nil {
+		t.Fatalf("Expected request with context to reach deadline: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error Timeout interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected := `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}
+
+func TestContextSubNextMsgWithDeadline(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	ctx, cancelCB := context.WithDeadline(context.Background(), deadline)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	sub, err := nc.SubscribeSync("slow")
+	if err != nil {
+		t.Fatalf("Expected to be able to subscribe: %s", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		err := nc.Publish("slow", []byte("OK"))
+		if err != nil {
+			t.Fatalf("Expected publish to not fail: %s", err)
+		}
+		// Enough time to get a couple of messages
+		time.Sleep(40 * time.Millisecond)
+
+		msg, err := sub.NextMsgWithContext(ctx)
+		if err != nil {
+			t.Fatalf("Expected to receive message: %s", err)
+		}
+		got := string(msg.Data)
+		expected := "OK"
+		if got != expected {
+			t.Errorf("Expected to receive %s, got: %s", expected, got)
+		}
+	}
+
+	// Third message will fail because the context will be canceled by now
+	_, err = sub.NextMsgWithContext(ctx)
+	if err == nil {
+		t.Fatalf("Expected to fail receiving a message: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error Timeout interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected := `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}
+
+func TestContextEncodedRequestWithDeadline(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc := NewDefaultConnection(t)
+	c, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
+	if err != nil {
+		t.Fatalf("Unable to create encoded connection: %v", err)
+	}
+	defer c.Close()
+
+	deadline := time.Now().Add(100 * time.Millisecond)
+	ctx, cancelCB := context.WithDeadline(context.Background(), deadline)
+	defer cancelCB() // should always be called, not discarded, to prevent context leak
+
+	type request struct {
+		Message string `json:"message"`
+	}
+	type response struct {
+		Code int `json:"code"`
+	}
+	c.Subscribe("slow", func(_, reply string, req *request) {
+		got := req.Message
+		expected := "Hello"
+		if got != expected {
+			t.Errorf("Expected to receive request with %q, got %q", got, expected)
+		}
+
+		// simulates latency into the client so that timeout is hit.
+		time.Sleep(40 * time.Millisecond)
+		c.Publish(reply, &response{Code: 200})
+	})
+
+	for i := 0; i < 2; i++ {
+		req := &request{Message: "Hello"}
+		resp := &response{}
+		err := c.RequestWithContext(ctx, "slow", req, resp)
+		if err != nil {
+			t.Fatalf("Expected encoded request with context to not fail: %s", err)
+		}
+		got := resp.Code
+		expected := 200
+		if got != expected {
+			t.Errorf("Expected to receive %v, got: %v", expected, got)
+		}
+	}
+
+	// A third request with latency would make the context
+	// reach the deadline.
+	req := &request{Message: "Hello"}
+	resp := &response{}
+	err = c.RequestWithContext(ctx, "slow", req, resp)
+	if err == nil {
+		t.Fatalf("Expected request with context to reach deadline: %s", err)
+	}
+
+	// Reported error is "context deadline exceeded" from Context package,
+	// which implements net.Error Timeout interface.
+	type timeoutError interface {
+		Timeout() bool
+	}
+	timeoutErr, ok := err.(timeoutError)
+	if !ok || !timeoutErr.Timeout() {
+		t.Errorf("Expected to have a timeout error")
+	}
+	expected := `context deadline exceeded`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("Expected %q error, got: %q", expected, err.Error())
+	}
+}

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -419,7 +419,7 @@ func TestContextSubNextMsgWithCancel(t *testing.T) {
 
 	// We do not have another message pending so timer will
 	// cancel the context.
-	resp, err = sub2.NextMsgWithContext(ctx)
+	_, err = sub2.NextMsgWithContext(ctx)
 	if err == nil {
 		t.Fatalf("Expected request with context to fail: %s", err)
 	}
@@ -602,7 +602,7 @@ func TestContextEncodedRequestWithTimeoutCanceled(t *testing.T) {
 	// Fast request should not fail
 	req := &request{Message: "Hello"}
 	resp := &response{}
-	err = c.RequestWithContext(ctx, "fast", req, resp)
+	c.RequestWithContext(ctx, "fast", req, resp)
 	expectedCode := 200
 	if resp.Code != expectedCode {
 		t.Errorf("Expected to receive %d, got: %d", expectedCode, resp.Code)


### PR DESCRIPTION
Adds `context.Context` support to the +Go1.7 clients implementing the APIs suggested at https://github.com/nats-io/go-nats/issues/221#issuecomment-288193653

```go
func (c *EncodedConn) RequestWithContext(ctx context.Context, subject string, v interface{}, vPtr interface{}) error
func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte) (*Msg, error)
func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error)
```

Fixes #221 
