### PR TITLE
Add output to example_test.go

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -28,6 +28,9 @@ func ExampleConnect() {
 
 	nc, _ = opts.Connect()
 	nc.Close()
+
+	// Output:
+	//
 }
 
 // This Example shows an asynchronous subscriber.
@@ -38,6 +41,9 @@ func ExampleConn_Subscribe() {
 	nc.Subscribe("foo", func(m *nats.Msg) {
 		fmt.Printf("Received a message: %s\n", string(m.Data))
 	})
+
+	// Output:
+	//
 }
 
 // This Example shows a synchronous subscriber.
@@ -52,6 +58,9 @@ func ExampleConn_SubscribeSync() {
 	} else {
 		fmt.Println("NextMsg timed out.")
 	}
+
+	// Output:
+	// NextMsg timed out.
 }
 
 func ExampleSubscription_NextMsg() {
@@ -65,6 +74,9 @@ func ExampleSubscription_NextMsg() {
 	} else {
 		fmt.Println("NextMsg timed out.")
 	}
+
+	// Output:
+	// NextMsg timed out.
 }
 
 func ExampleSubscription_Unsubscribe() {
@@ -74,6 +86,9 @@ func ExampleSubscription_Unsubscribe() {
 	sub, _ := nc.SubscribeSync("foo")
 	// ...
 	sub.Unsubscribe()
+
+	// Output:
+	//
 }
 
 func ExampleConn_Publish() {
@@ -81,6 +96,9 @@ func ExampleConn_Publish() {
 	defer nc.Close()
 
 	nc.Publish("foo", []byte("Hello World!"))
+
+	// Output:
+	//
 }
 
 func ExampleConn_PublishMsg() {
@@ -89,6 +107,9 @@ func ExampleConn_PublishMsg() {
 
 	msg := &nats.Msg{Subject: "foo", Reply: "bar", Data: []byte("Hello World!")}
 	nc.PublishMsg(msg)
+
+	// Output:
+	//
 }
 
 func ExampleConn_Flush() {
@@ -103,6 +124,9 @@ func ExampleConn_Flush() {
 	if err == nil {
 		// Everything has been processed by the server for nc *Conn.
 	}
+
+	// Output:
+	//
 }
 
 func ExampleConn_FlushTimeout() {
@@ -118,6 +142,9 @@ func ExampleConn_FlushTimeout() {
 	if err == nil {
 		// Everything has been processed by the server for nc *Conn.
 	}
+
+	// Output:
+	//
 }
 
 func ExampleConn_Request() {
@@ -127,7 +154,13 @@ func ExampleConn_Request() {
 	nc.Subscribe("foo", func(m *nats.Msg) {
 		nc.Publish(m.Reply, []byte("I will help you"))
 	})
-	nc.Request("foo", []byte("help"), 50*time.Millisecond)
+	response, err := nc.Request("foo", []byte("help"), 50*time.Millisecond)
+	if err == nil {
+		fmt.Println(string(response.Data))
+	}
+
+	// Output:
+	// I will help you
 }
 
 func ExampleConn_QueueSubscribe() {
@@ -139,6 +172,9 @@ func ExampleConn_QueueSubscribe() {
 	nc.QueueSubscribe("foo", "worker_group", func(_ *nats.Msg) {
 		received++
 	})
+
+	// Output:
+	//
 }
 
 func ExampleSubscription_AutoUnsubscribe() {
@@ -158,11 +194,17 @@ func ExampleSubscription_AutoUnsubscribe() {
 	nc.Flush()
 
 	fmt.Printf("Received = %d", received)
+
+	// Output:
+	// Received = 10
 }
 
 func ExampleConn_Close() {
 	nc, _ := nats.Connect(nats.DefaultURL)
 	nc.Close()
+
+	// Output:
+	//
 }
 
 // Shows how to wrap a Conn into an EncodedConn
@@ -170,6 +212,9 @@ func ExampleNewEncodedConn() {
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	c.Close()
+
+	// Output:
+	//
 }
 
 // EncodedConn can publish virtually anything just
@@ -188,6 +233,9 @@ func ExampleEncodedConn_Publish() {
 
 	me := &person{Name: "derek", Age: 22, Address: "85 Second St"}
 	c.Publish("hello", me)
+
+	// Output:
+	//
 }
 
 // EncodedConn's subscribers will automatically decode the
@@ -216,6 +264,9 @@ func ExampleEncodedConn_Subscribe() {
 
 	me := &person{Name: "derek", Age: 22, Address: "85 Second St"}
 	c.Publish("hello", me)
+
+	// Output:
+	//
 }
 
 // BindSendChan() allows binding of a Go channel to a nats
@@ -237,6 +288,9 @@ func ExampleEncodedConn_BindSendChan() {
 
 	me := &person{Name: "derek", Age: 22, Address: "85 Second St"}
 	ch <- me
+
+	// Output:
+	//
 }
 
 // BindRecvChan() allows binding of a Go channel to a nats
@@ -263,4 +317,7 @@ func ExampleEncodedConn_BindRecvChan() {
 	who := <-ch
 
 	fmt.Printf("%v says hello!\n", who)
+
+	// Output:
+	// &{derek 85 Second St 22} says hello!
 }

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Shows different ways to create a Conn
-func ExampleConnect() {
+func Example_nats_Connect() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -36,7 +36,7 @@ func ExampleConnect() {
 }
 
 // This Example shows an asynchronous subscriber.
-func ExampleConn_Subscribe() {
+func Example_nats_Connect_Subscribe() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -52,7 +52,7 @@ func ExampleConn_Subscribe() {
 }
 
 // This Example shows a synchronous subscriber.
-func ExampleConn_SubscribeSync() {
+func Example_nats_Connect_SubscribeSync() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -71,7 +71,7 @@ func ExampleConn_SubscribeSync() {
 	// NextMsg timed out.
 }
 
-func ExampleSubscription_NextMsg() {
+func Example_nats_Subscription_NextMsg() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -90,7 +90,7 @@ func ExampleSubscription_NextMsg() {
 	// NextMsg timed out.
 }
 
-func ExampleSubscription_Unsubscribe() {
+func Example_nats_Subscription_Unsubscribe() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -105,7 +105,7 @@ func ExampleSubscription_Unsubscribe() {
 	//
 }
 
-func ExampleConn_Publish() {
+func Example_nats_Connect_Publish() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -118,7 +118,7 @@ func ExampleConn_Publish() {
 	//
 }
 
-func ExampleConn_PublishMsg() {
+func Example_nats_Connect_PublishMsg() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -132,7 +132,7 @@ func ExampleConn_PublishMsg() {
 	//
 }
 
-func ExampleConn_Flush() {
+func Example_nats_Connect_Flush() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -152,7 +152,7 @@ func ExampleConn_Flush() {
 	//
 }
 
-func ExampleConn_FlushTimeout() {
+func Example_nats_Connect_FlushTimeout() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -173,7 +173,7 @@ func ExampleConn_FlushTimeout() {
 	//
 }
 
-func ExampleConn_Request() {
+func Example_nats_Connect_Request() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -192,7 +192,7 @@ func ExampleConn_Request() {
 	// I will help you
 }
 
-func ExampleConn_QueueSubscribe() {
+func Example_nats_Connect_QueueSubscribe() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -209,7 +209,7 @@ func ExampleConn_QueueSubscribe() {
 	//
 }
 
-func ExampleSubscription_AutoUnsubscribe() {
+func Example_nats_Subscription_AutoUnsubscribe() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -234,7 +234,7 @@ func ExampleSubscription_AutoUnsubscribe() {
 	// Received = 10
 }
 
-func ExampleConn_Close() {
+func Example_nats_Connect_Close() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -246,7 +246,7 @@ func ExampleConn_Close() {
 }
 
 // Shows how to wrap a Conn into an EncodedConn
-func ExampleNewEncodedConn() {
+func Example_nats_NewEncodedConn() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -261,7 +261,7 @@ func ExampleNewEncodedConn() {
 // EncodedConn can publish virtually anything just
 // by passing it in. The encoder will be used to properly
 // encode the raw Go type
-func ExampleEncodedConn_Publish() {
+func Example_nats_EncodedConn_Publish() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -287,7 +287,7 @@ func ExampleEncodedConn_Publish() {
 // method of the registered Encoder. The callback signature
 // can also vary to include additional data, such as subject
 // and reply subjects.
-func ExampleEncodedConn_Subscribe() {
+func Example_nats_EncodedConn_Subscribe() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -319,7 +319,7 @@ func ExampleEncodedConn_Subscribe() {
 // BindSendChan() allows binding of a Go channel to a nats
 // subject for publish operations. The Encoder attached to the
 // EncodedConn will be used for marshalling.
-func ExampleEncodedConn_BindSendChan() {
+func Example_nats_EncodedConn_BindSendChan() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
@@ -346,7 +346,7 @@ func ExampleEncodedConn_BindSendChan() {
 // BindRecvChan() allows binding of a Go channel to a nats
 // subject for subscribe operations. The Encoder attached to the
 // EncodedConn will be used for un-marshalling.
-func ExampleEncodedConn_BindRecvChan() {
+func Example_nats_EncodedConn_BindRecvChan() {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -60,7 +60,9 @@ func Example_nats_Connect_SubscribeSync() {
 	defer nc.Close()
 
 	sub, _ := nc.SubscribeSync("foo")
-	m, err := sub.NextMsg(1 * time.Second)
+
+	// Expecting to timeout here since no one has published a message.
+	m, err := sub.NextMsg(1 * time.Millisecond)
 	if err == nil {
 		fmt.Printf("Received a message: %s\n", string(m.Data))
 	} else {
@@ -78,8 +80,9 @@ func Example_nats_Subscription_NextMsg() {
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
+	// Expecting to timeout here since no one has published a message.
 	sub, _ := nc.SubscribeSync("foo")
-	m, err := sub.NextMsg(1 * time.Second)
+	m, err := sub.NextMsg(1 * time.Millisecond)
 	if err == nil {
 		fmt.Printf("Received a message: %s\n", string(m.Data))
 	} else {

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -1,4 +1,4 @@
-package nats_test
+package test
 
 import (
 	"fmt"
@@ -9,6 +9,8 @@ import (
 
 // Shows different ways to create a Conn
 func ExampleConnect() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
 
 	nc, _ := nats.Connect(nats.DefaultURL)
 	nc.Close()
@@ -35,6 +37,9 @@ func ExampleConnect() {
 
 // This Example shows an asynchronous subscriber.
 func ExampleConn_Subscribe() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -48,6 +53,9 @@ func ExampleConn_Subscribe() {
 
 // This Example shows a synchronous subscriber.
 func ExampleConn_SubscribeSync() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -64,6 +72,9 @@ func ExampleConn_SubscribeSync() {
 }
 
 func ExampleSubscription_NextMsg() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -80,6 +91,9 @@ func ExampleSubscription_NextMsg() {
 }
 
 func ExampleSubscription_Unsubscribe() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -92,6 +106,9 @@ func ExampleSubscription_Unsubscribe() {
 }
 
 func ExampleConn_Publish() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -102,6 +119,9 @@ func ExampleConn_Publish() {
 }
 
 func ExampleConn_PublishMsg() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -113,6 +133,9 @@ func ExampleConn_PublishMsg() {
 }
 
 func ExampleConn_Flush() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -130,6 +153,9 @@ func ExampleConn_Flush() {
 }
 
 func ExampleConn_FlushTimeout() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -148,6 +174,9 @@ func ExampleConn_FlushTimeout() {
 }
 
 func ExampleConn_Request() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -164,6 +193,9 @@ func ExampleConn_Request() {
 }
 
 func ExampleConn_QueueSubscribe() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -178,6 +210,9 @@ func ExampleConn_QueueSubscribe() {
 }
 
 func ExampleSubscription_AutoUnsubscribe() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	defer nc.Close()
 
@@ -200,6 +235,9 @@ func ExampleSubscription_AutoUnsubscribe() {
 }
 
 func ExampleConn_Close() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	nc.Close()
 
@@ -209,6 +247,9 @@ func ExampleConn_Close() {
 
 // Shows how to wrap a Conn into an EncodedConn
 func ExampleNewEncodedConn() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	c.Close()
@@ -221,6 +262,9 @@ func ExampleNewEncodedConn() {
 // by passing it in. The encoder will be used to properly
 // encode the raw Go type
 func ExampleEncodedConn_Publish() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	defer c.Close()
@@ -244,6 +288,9 @@ func ExampleEncodedConn_Publish() {
 // can also vary to include additional data, such as subject
 // and reply subjects.
 func ExampleEncodedConn_Subscribe() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	defer c.Close()
@@ -273,6 +320,9 @@ func ExampleEncodedConn_Subscribe() {
 // subject for publish operations. The Encoder attached to the
 // EncodedConn will be used for marshalling.
 func ExampleEncodedConn_BindSendChan() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	defer c.Close()
@@ -297,6 +347,9 @@ func ExampleEncodedConn_BindSendChan() {
 // subject for subscribe operations. The Encoder attached to the
 // EncodedConn will be used for un-marshalling.
 func ExampleEncodedConn_BindRecvChan() {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
 	nc, _ := nats.Connect(nats.DefaultURL)
 	c, _ := nats.NewEncodedConn(nc, "json")
 	defer c.Close()


### PR DESCRIPTION
Noticed that we are missing the `Output` comments section in the examples from `example_test`, so this PR includes them in order to run these examples as part of the build.