### PR TITLE
[ADDED] Handler invoked when a new server joins the NATS Cluster

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -191,6 +191,10 @@ type Options struct {
 	// successfully reconnected.
 	ReconnectedCB ConnHandler
 
+	// DiscoveredServersCB sets the callback that is invoked whenever a new
+	// server has joined the cluster.
+	DiscoveredServersCB ConnHandler
+
 	// AsyncErrorCB sets the async error handler (e.g. slow consumer errors)
 	AsyncErrorCB ErrHandler
 
@@ -261,6 +265,7 @@ type Conn struct {
 	pongs   []chan bool
 	scratch [scratchSize]byte
 	status  Status
+	initc   bool // true if the connection is performing the initial connect
 	err     error
 	ps      *parseState
 	ptmr    *time.Timer
@@ -524,6 +529,14 @@ func ClosedHandler(cb ConnHandler) Option {
 	}
 }
 
+// DiscoveredServersHandler is an Option to set the new servers handler.
+func DiscoveredServersHandler(cb ConnHandler) Option {
+	return func(o *Options) error {
+		o.DiscoveredServersCB = cb
+		return nil
+	}
+}
+
 // ErrHandler is an Option to set the async error  handler.
 func ErrorHandler(cb ErrHandler) Option {
 	return func(o *Options) error {
@@ -580,6 +593,16 @@ func (nc *Conn) SetReconnectHandler(rcb ConnHandler) {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
 	nc.Opts.ReconnectedCB = rcb
+}
+
+// SetDiscoveredServersHandler will set the discovered servers handler.
+func (nc *Conn) SetDiscoveredServersHandler(dscb ConnHandler) {
+	if nc == nil {
+		return
+	}
+	nc.mu.Lock()
+	defer nc.mu.Unlock()
+	nc.Opts.DiscoveredServersCB = dscb
 }
 
 // SetClosedHandler will set the reconnect event handler.
@@ -991,6 +1014,7 @@ func (nc *Conn) connect() error {
 	// For first connect we walk all servers in the pool and try
 	// to connect immediately.
 	nc.mu.Lock()
+	nc.initc = true
 	// The pool may change inside theloop iteration due to INFO protocol.
 	for i := 0; i < len(nc.srvPool); i++ {
 		nc.url = nc.srvPool[i].url
@@ -1022,6 +1046,7 @@ func (nc *Conn) connect() error {
 			}
 		}
 	}
+	nc.initc = false
 	defer nc.mu.Unlock()
 
 	if returnedErr == nil && nc.status != CONNECTED {
@@ -1720,6 +1745,7 @@ func (nc *Conn) processInfo(info string) error {
 	}
 	urls := nc.info.ConnectURLs
 	if len(urls) > 0 {
+		added := false
 		// If randomization is allowed, shuffle the received array, not the
 		// entire pool. We want to preserve the pool's order up to this point
 		// (this would otherwise be problematic for the (re)connect loop).
@@ -1734,7 +1760,11 @@ func (nc *Conn) processInfo(info string) error {
 				if err := nc.addURLToPool(fmt.Sprintf("nats://%s", curl), true); err != nil {
 					continue
 				}
+				added = true
 			}
+		}
+		if added && !nc.initc && nc.Opts.DiscoveredServersCB != nil {
+			nc.ach <- func() { nc.Opts.DiscoveredServersCB(nc) }
 		}
 	}
 	return nil

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/gnatsd/server"
+	"github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats"
 )
 
@@ -1391,5 +1393,75 @@ func TestCustomFlusherTimeout(t *testing.T) {
 			t.Errorf("Timeout publishing messages")
 			return
 		}
+	}
+}
+
+func TestNewServers(t *testing.T) {
+	s1Opts := test.DefaultTestOptions
+	s1Opts.Cluster.Host = "localhost"
+	s1Opts.Cluster.Port = 6222
+	s1 := test.RunServer(&s1Opts)
+	defer s1.Shutdown()
+
+	s2Opts := test.DefaultTestOptions
+	s2Opts.Port = s1Opts.Port + 1
+	s2Opts.Cluster.Host = "localhost"
+	s2Opts.Cluster.Port = 6223
+	s2Opts.Routes = server.RoutesFromStr("nats://localhost:6222")
+	s2 := test.RunServer(&s2Opts)
+	defer s2.Shutdown()
+
+	ch := make(chan bool)
+	cb := func(_ *nats.Conn) {
+		ch <- true
+	}
+	url := fmt.Sprintf("nats://%s:%d", s1Opts.Host, s1Opts.Port)
+	nc1, err := nats.Connect(url, nats.DiscoveredServersHandler(cb))
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc1.Close()
+
+	nc2, err := nats.Connect(url)
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc2.Close()
+	nc2.SetDiscoveredServersHandler(cb)
+
+	opts := nats.DefaultOptions
+	opts.Url = nats.DefaultURL
+	opts.DiscoveredServersCB = cb
+	nc3, err := opts.Connect()
+	if err != nil {
+		t.Fatalf("Error on connect: %v", err)
+	}
+	defer nc3.Close()
+
+	// Make sure that handler is not invoked on initial connect.
+	select {
+	case <-ch:
+		t.Fatalf("Handler should not have been invoked")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Start a new server.
+	s3Opts := test.DefaultTestOptions
+	s3Opts.Port = s2Opts.Port + 1
+	s3Opts.Cluster.Host = "localhost"
+	s3Opts.Cluster.Port = 6224
+	s3Opts.Routes = server.RoutesFromStr("nats://localhost:6222")
+	s3 := test.RunServer(&s3Opts)
+	defer s3.Shutdown()
+
+	// The callbacks should have been invoked
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our callback")
+	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our callback")
+	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Did not get our callback")
 	}
 }


### PR DESCRIPTION
If `DiscoveredServersCB` is set, the client library will invoke this
callback when it is notified by the server it connects to that
a new server has joined the cluster. This callback is not invoked
in the initial `Connect()`. A ConnHandler is used. The user can
invoke `nc.DiscoveredServers()` to get the list of discovered servers.

But in some cases, it is just enough to know that a new server
has joined. A use case is in NATS Streaming server with the
channels partitioning/sharding feature where a server needs to know
if the cluster has changed in which case it should resend its list
of channels.