### PR TITLE
[FIXED] Locking in processPermissionsViolation() and added test

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1655,10 +1655,12 @@ slowConsumer:
 // processPermissionsViolation is called when the server signals a subject
 // permissions violation on either publish or subscribe.
 func (nc *Conn) processPermissionsViolation(err string) {
+	nc.mu.Lock()
 	nc.err = errors.New("nats: " + err)
 	if nc.Opts.AsyncErrorCB != nil {
 		nc.ach <- func() { nc.Opts.AsyncErrorCB(nc, nil, nc.err) }
 	}
+	nc.mu.Unlock()
 }
 
 // flusher is a separate Go routine that will process flush requests for the write


### PR DESCRIPTION
Connection locking was missing in processPermissionsViolation().
Added a test that verifies that async cb error is invoked on
invalid publish or subscribe, and that the connection is not
closed neither by the server nor client.

@derekcollison Opening this for discussion: was it the proper intent for the server to keep the client connection (not closing it at the moment)? If so, then it makes sense for the client also to not close it and treat this as a non fatal error. This PR then simply fixes the locking and add a test (coverage was non existent for this function).