### PR TITLE
Pool timers to avoid allocations

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2056,8 +2056,8 @@ func (nc *Conn) Request(subj string, data []byte, timeout time.Duration) (*Msg, 
 		return nil, err
 	}
 
-	t := time.NewTimer(timeout)
-	defer t.Stop()
+	t := globalTimerPool.Get(timeout)
+	defer globalTimerPool.Put(t)
 
 	var ok bool
 	var msg *Msg
@@ -2380,8 +2380,8 @@ func (s *Subscription) NextMsg(timeout time.Duration) (*Msg, error) {
 	var ok bool
 	var msg *Msg
 
-	t := time.NewTimer(timeout)
-	defer t.Stop()
+	t := globalTimerPool.Get(timeout)
+	defer globalTimerPool.Put(t)
 
 	select {
 	case msg, ok = <-mch:
@@ -2652,8 +2652,8 @@ func (nc *Conn) FlushTimeout(timeout time.Duration) (err error) {
 		nc.mu.Unlock()
 		return ErrConnectionClosed
 	}
-	t := time.NewTimer(timeout)
-	defer t.Stop()
+	t := globalTimerPool.Get(timeout)
+	defer globalTimerPool.Put(t)
 
 	ch := make(chan bool) // FIXME: Inefficient?
 	nc.sendPing(ch)

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,43 @@
+package nats
+
+import (
+	"sync"
+	"time"
+)
+
+// global pool of *time.Timer's. can be used by multiple goroutines concurrently.
+var globalTimerPool timerPool
+
+// timerPool provides GC-able pooling of *time.Timer's.
+// can be used by multiple goroutines concurrently.
+type timerPool struct {
+	p sync.Pool
+}
+
+// Get returns a timer that completes after the given duration.
+func (tp *timerPool) Get(d time.Duration) *time.Timer {
+	if t, _ := tp.p.Get().(*time.Timer); t != nil {
+		t.Reset(d)
+		return t
+	}
+
+	return time.NewTimer(d)
+}
+
+// Put pools the given timer.
+//
+// There is no need to call t.Stop() before calling Put.
+//
+// Put will try to stop the timer before pooling. If the
+// given timer already expired, Put will read the unreceived
+// value if there is one.
+func (tp *timerPool) Put(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+
+	tp.p.Put(t)
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,0 +1,50 @@
+package nats
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+)
+
+func TestTimerPool(t *testing.T) {
+	// This test modifies runtime behaviour and must not be run concurrently
+	// with other tests so we can't call t.Parallel
+
+	// Force a single P to avoid the current goroutine from being scheduled
+	// onto another P. this is needed as sync.Pool will keep one value on a
+	// per-P cache.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
+	// Disable GC to prevent the pool from being emptied while testing
+	defer debug.SetGCPercent(debug.SetGCPercent(0))
+
+	var tp timerPool
+
+	t1 := time.NewTimer(time.Hour)
+	tp.Put(t1)
+
+	t2 := tp.Get(time.Millisecond * 25)
+
+	if t1 != t2 {
+		t.Errorf("Got new timer")
+	}
+
+	select {
+	case <-t2.C:
+	case <-time.After(time.Millisecond * 100):
+		t.Errorf("Timer from pool didn't expire in time")
+	}
+
+	t3 := tp.Get(time.Millisecond * 25)
+
+	if t2 == t3 {
+		t.Errorf("Got old timer")
+	}
+
+	select {
+	case <-t3.C:
+	case <-time.After(time.Millisecond * 100):
+		t.Errorf("New timer didn't expire in time")
+	}
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTimerPool(t *testing.T) {
-	// This test modifies runtime behaviour and must not be run concurrently
+	// This test modifies runtime behavior and must not be run concurrently
 	// with other tests so we can't call t.Parallel
 
 	// Force a single P to avoid the current goroutine from being scheduled

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,50 +1,29 @@
 package nats
 
 import (
-	"runtime"
-	"runtime/debug"
 	"testing"
 	"time"
 )
 
 func TestTimerPool(t *testing.T) {
-	// This test modifies runtime behavior and must not be run concurrently
-	// with other tests so we can't call t.Parallel
-
-	// Force a single P to avoid the current goroutine from being scheduled
-	// onto another P. this is needed as sync.Pool will keep one value on a
-	// per-P cache.
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
-
-	// Disable GC to prevent the pool from being emptied while testing
-	defer debug.SetGCPercent(debug.SetGCPercent(0))
-
 	var tp timerPool
 
-	t1 := time.NewTimer(time.Hour)
-	tp.Put(t1)
+	for i := 0; i < 10; i++ {
+		tm := tp.Get(time.Millisecond * 20)
 
-	t2 := tp.Get(time.Millisecond * 25)
+		select {
+		case <-tm.C:
+			t.Errorf("Timer already expired")
+			continue
+		default:
+		}
 
-	if t1 != t2 {
-		t.Errorf("Got new timer")
-	}
+		select {
+		case <-tm.C:
+		case <-time.After(time.Millisecond * 100):
+			t.Errorf("Timer didn't expire in time")
+		}
 
-	select {
-	case <-t2.C:
-	case <-time.After(time.Millisecond * 100):
-		t.Errorf("Timer from pool didn't expire in time")
-	}
-
-	t3 := tp.Get(time.Millisecond * 25)
-
-	if t2 == t3 {
-		t.Errorf("Got old timer")
-	}
-
-	select {
-	case <-t3.C:
-	case <-time.After(time.Millisecond * 100):
-		t.Errorf("New timer didn't expire in time")
+		tp.Put(tm)
 	}
 }


### PR DESCRIPTION
Requests are somewhat allocation heavy. This should help a bit. Also has a small positive effect on requests performance (more for the old request style).

Benchstat (base 9147cfac69833916f9c73353ba43f939815c330a):

```
name                              old time/op    new time/op    delta
Request-8                           43.9µs ± 5%    43.4µs ± 1%     ~     (p=0.690 n=5+5)
OldRequest-8                        60.0µs ± 3%    57.5µs ± 2%   -4.30%  (p=0.008 n=5+5)

name                              old alloc/op   new alloc/op   delta
Request-8                             885B ± 0%      693B ± 0%  -21.71%  (p=0.008 n=5+5)
OldRequest-8                        2.63kB ± 0%    2.44kB ± 0%   -7.27%  (p=0.000 n=5+4)

name                              old allocs/op  new allocs/op  delta
Request-8                             17.0 ± 0%      14.0 ± 0%  -17.65%  (p=0.008 n=5+5)
OldRequest-8                          55.0 ± 0%      52.0 ± 0%   -5.45%  (p=0.008 n=5+5)
```

Other benchmarks show no changes.