### PR TITLE
Fix new-style request leak

### DIFF
--- a/context.go
+++ b/context.go
@@ -40,12 +40,13 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 	token := respToken(respInbox)
 	nc.respMap[token] = mch
 	createSub := nc.respMux == nil
+	ginbox := nc.respSub
 	nc.mu.Unlock()
 
 	if createSub {
 		// Make sure scoped subscription is setup only once.
 		var err error
-		nc.respSetup.Do(func() { err = nc.createRespMux() })
+		nc.respSetup.Do(func() { err = nc.createRespMux(ginbox) })
 		if err != nil {
 			return nil, err
 		}

--- a/context.go
+++ b/context.go
@@ -65,6 +65,9 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 			return nil, ErrConnectionClosed
 		}
 	case <-ctx.Done():
+		nc.mu.Lock()
+		delete(nc.respMap, token)
+		nc.mu.Unlock()
 		return nil, ctx.Err()
 	}
 


### PR DESCRIPTION
The new request style was leaking channels in the respMap when requests
timed out. Now we remove them from the map when the request times out.

This also simplifies the respMux setup and prevents multiple resp
subscriptions from being created on the server.

@nats-io/core 