### PR TITLE
Make DefaultOptions a function that produces new Options on every call

### DIFF
--- a/examples/nats-bench.go
+++ b/examples/nats-bench.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	// Setup the option block
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = strings.Split(*urls, ",")
 	for i, s := range opts.Servers {
 		opts.Servers[i] = strings.Trim(s, " ")

--- a/nats.go
+++ b/nats.go
@@ -79,19 +79,27 @@ var (
 	ErrStaleConnection      = errors.New("nats: " + STALE_CONNECTION)
 )
 
-var DefaultOptions = Options{
-	AllowReconnect:   true,
-	MaxReconnect:     DefaultMaxReconnect,
-	ReconnectWait:    DefaultReconnectWait,
-	Timeout:          DefaultTimeout,
-	PingInterval:     DefaultPingInterval,
-	MaxPingsOut:      DefaultMaxPingOut,
-	SubChanLen:       DefaultMaxChanLen,
-	ReconnectBufSize: DefaultReconnectBufSize,
-	Dialer: &net.Dialer{
-		Timeout: DefaultTimeout,
-	},
+func GetDefaultOptions() Options {
+	opts := Options{
+		AllowReconnect:   true,
+		MaxReconnect:     DefaultMaxReconnect,
+		ReconnectWait:    DefaultReconnectWait,
+		Timeout:          DefaultTimeout,
+		PingInterval:     DefaultPingInterval,
+		MaxPingsOut:      DefaultMaxPingOut,
+		SubChanLen:       DefaultMaxChanLen,
+		ReconnectBufSize: DefaultReconnectBufSize,
+		Dialer: &net.Dialer{
+			Timeout: DefaultTimeout,
+		},
+	}
+	return opts
 }
+
+// DEPRECATED: Use GetDefaultOptions() instead.
+// DefaultOptions is not safe for use by multiple clients.
+// For details see #308.
+var DefaultOptions = GetDefaultOptions()
 
 // Status represents the state of the connection.
 type Status int
@@ -399,7 +407,7 @@ type MsgHandler func(msg *Msg)
 // Comma separated arrays are also supported, e.g. urlA, urlB.
 // Options start with the defaults but can be overridden.
 func Connect(url string, options ...Option) (*Conn, error) {
-	opts := DefaultOptions
+	opts := GetDefaultOptions()
 	opts.Servers = processUrlString(url)
 	for _, opt := range options {
 		if err := opt(&opts); err != nil {

--- a/nats_test.go
+++ b/nats_test.go
@@ -191,7 +191,7 @@ var testServers = []string{
 }
 
 func TestServersRandomize(t *testing.T) {
-	opts := DefaultOptions
+	opts := GetDefaultOptions()
 	opts.Servers = testServers
 	nc := &Conn{Opts: opts}
 	if err := nc.setupServerPool(); err != nil {
@@ -208,7 +208,7 @@ func TestServersRandomize(t *testing.T) {
 	}
 
 	// Now test that we do not randomize if proper flag is set.
-	opts = DefaultOptions
+	opts = GetDefaultOptions()
 	opts.Servers = testServers
 	opts.NoRandomize = true
 	nc = &Conn{Opts: opts}
@@ -228,7 +228,7 @@ func TestServersRandomize(t *testing.T) {
 	// set, Opts.Servers is not (and vice versa), the behavior
 	// is that Opts.Url is always first, even when randomization
 	// is enabled. So make sure that this is still the case.
-	opts = DefaultOptions
+	opts = GetDefaultOptions()
 	opts.Url = DefaultURL
 	opts.Servers = testServers
 	nc = &Conn{Opts: opts}
@@ -250,7 +250,7 @@ func TestServersRandomize(t *testing.T) {
 }
 
 func TestSelectNextServer(t *testing.T) {
-	opts := DefaultOptions
+	opts := GetDefaultOptions()
 	opts.Servers = testServers
 	opts.NoRandomize = true
 	nc := &Conn{Opts: opts}
@@ -832,7 +832,7 @@ func TestNormalizeError(t *testing.T) {
 }
 
 func TestAsyncINFO(t *testing.T) {
-	opts := DefaultOptions
+	opts := GetDefaultOptions()
 	c := &Conn{Opts: opts}
 
 	c.ps = &parseState{}
@@ -1097,7 +1097,7 @@ func TestAsyncINFO(t *testing.T) {
 }
 
 func TestConnServers(t *testing.T) {
-	opts := DefaultOptions
+	opts := GetDefaultOptions()
 	c := &Conn{Opts: opts}
 	c.ps = &parseState{}
 	c.setupServerPool()

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -59,7 +59,7 @@ func TestAuthFailNoDisconnectCB(t *testing.T) {
 	s := RunServerWithOptions(opts)
 	defer s.Shutdown()
 
-	copts := nats.DefaultOptions
+	copts := nats.GetDefaultOptions()
 	copts.Url = "nats://localhost:8232"
 	receivedDisconnectCB := int32(0)
 	copts.DisconnectedCB = func(nc *nats.Conn) {
@@ -97,7 +97,7 @@ func TestAuthFailAllowReconnect(t *testing.T) {
 
 	reconnectch := make(chan bool)
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = servers
 	opts.AllowReconnect = true
 	opts.NoRandomize = true

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -109,7 +109,7 @@ func TestBadOptionTimeoutConnect(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Timeout = -1
 	opts.Url = "nats://localhost:4222"
 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -26,7 +26,7 @@ var testServers = []string{
 var servers = strings.Join(testServers, ",")
 
 func TestServersOption(t *testing.T) {
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.NoRandomize = true
 
 	_, err := opts.Connect()
@@ -298,7 +298,7 @@ func TestProperReconnectDelay(t *testing.T) {
 	defer s1.Shutdown()
 
 	var srvs string
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	if runtime.GOOS == "windows" {
 		srvs = strings.Join(testServers[:2], ",")
 	} else {
@@ -352,7 +352,7 @@ func TestProperFalloutAfterMaxAttempts(t *testing.T) {
 	s1 := RunServerOnPort(1222)
 	defer s1.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	// Reduce the list of servers for Windows tests
 	if runtime.GOOS == "windows" {
 		opts.Servers = testServers[:2]
@@ -421,7 +421,7 @@ func TestProperFalloutAfterMaxAttemptsWithAuthMismatch(t *testing.T) {
 	s2, _ := RunServerWithConfig("./configs/tlsverify.conf")
 	defer s2.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = myServers
 	opts.NoRandomize = true
 	if runtime.GOOS == "windows" {
@@ -488,7 +488,7 @@ func TestTimeoutOnNoServers(t *testing.T) {
 	s1 := RunServerOnPort(1222)
 	defer s1.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	if runtime.GOOS == "windows" {
 		opts.Servers = testServers[:2]
 		opts.MaxReconnect = 2
@@ -554,7 +554,7 @@ func TestPingReconnect(t *testing.T) {
 	s1 := RunServerOnPort(1222)
 	defer s1.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = testServers
 	opts.NoRandomize = true
 	opts.ReconnectWait = 200 * time.Millisecond

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -55,7 +55,7 @@ func TestConnClosedCB(t *testing.T) {
 	defer s.Shutdown()
 
 	ch := make(chan bool)
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.Url = nats.DefaultURL
 	o.ClosedCB = func(_ *nats.Conn) {
 		ch <- true
@@ -75,7 +75,7 @@ func TestCloseDisconnectedCB(t *testing.T) {
 	defer s.Shutdown()
 
 	ch := make(chan bool)
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.Url = nats.DefaultURL
 	o.AllowReconnect = false
 	o.DisconnectedCB = func(_ *nats.Conn) {
@@ -96,7 +96,7 @@ func TestServerStopDisconnectedCB(t *testing.T) {
 	defer s.Shutdown()
 
 	ch := make(chan bool)
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.Url = nats.DefaultURL
 	o.AllowReconnect = false
 	o.DisconnectedCB = func(nc *nats.Conn) {
@@ -484,7 +484,7 @@ func TestMoreErrOnConnect(t *testing.T) {
 
 	close(case1)
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = []string{natsURL}
 	opts.Timeout = 20 * time.Millisecond
 	opts.Verbose = true
@@ -557,7 +557,7 @@ func TestErrOnMaxPayloadLimit(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Servers = []string{natsURL}
 	nc, err := opts.Connect()
 	if err != nil {
@@ -583,7 +583,7 @@ func TestConnectVerbose(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.Verbose = true
 
 	nc, err := o.Connect()
@@ -844,7 +844,7 @@ func TestFlushReleaseOnClose(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.AllowReconnect = false
 	opts.Servers = []string{natsURL}
 	nc, err := opts.Connect()
@@ -911,7 +911,7 @@ func TestMaxPendingOut(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.PingInterval = 20 * time.Millisecond
 	opts.MaxPingsOut = 2
 	opts.AllowReconnect = false
@@ -985,7 +985,7 @@ func TestErrInReadLoop(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.AllowReconnect = false
 	opts.ClosedCB = func(_ *nats.Conn) { cch <- true }
 	opts.Servers = []string{natsURL}
@@ -1075,7 +1075,7 @@ func TestErrStaleConnection(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.AllowReconnect = true
 	opts.DisconnectedCB = func(_ *nats.Conn) {
 		// Interested only in the first disconnect cb
@@ -1166,7 +1166,7 @@ func TestServerErrorClosesConnection(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	natsURL := fmt.Sprintf("nats://%s:%d", addr.IP, addr.Port)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.AllowReconnect = true
 	opts.DisconnectedCB = func(_ *nats.Conn) { dch <- true }
 	opts.ReconnectedCB = func(_ *nats.Conn) { atomic.AddInt64(&reconnected, 1) }
@@ -1429,7 +1429,7 @@ func TestNewServers(t *testing.T) {
 	defer nc2.Close()
 	nc2.SetDiscoveredServersHandler(cb)
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Url = nats.DefaultURL
 	opts.DiscoveredServersCB = cb
 	nc3, err := opts.Connect()

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -15,7 +15,7 @@ func startReconnectServer(t *testing.T) *server.Server {
 }
 
 func TestReconnectTotalTime(t *testing.T) {
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	totalReconnectTime := time.Duration(opts.MaxReconnect) * opts.ReconnectWait
 	if totalReconnectTime < (2 * time.Minute) {
 		t.Fatalf("Total reconnect time should be at least 2 mins: Currently %v\n",
@@ -28,7 +28,7 @@ func TestReconnectDisallowedFlags(t *testing.T) {
 	defer ts.Shutdown()
 
 	ch := make(chan bool)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Url = "nats://localhost:22222"
 	opts.AllowReconnect = false
 	opts.ClosedCB = func(_ *nats.Conn) {
@@ -52,7 +52,7 @@ func TestReconnectAllowedFlags(t *testing.T) {
 	defer ts.Shutdown()
 	ch := make(chan bool)
 	dch := make(chan bool)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Url = "nats://localhost:22222"
 	opts.AllowReconnect = true
 	opts.MaxReconnect = 2
@@ -414,7 +414,7 @@ func TestIsReconnectingAndStatus(t *testing.T) {
 
 	disconnectedch := make(chan bool)
 	reconnectch := make(chan bool)
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Url = "nats://localhost:22222"
 	opts.AllowReconnect = true
 	opts.MaxReconnect = 10000
@@ -483,7 +483,7 @@ func TestFullFlushChanDuringReconnect(t *testing.T) {
 
 	reconnectch := make(chan bool)
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 	opts.Url = "nats://localhost:22222"
 	opts.AllowReconnect = true
 	opts.MaxReconnect = 10000
@@ -544,7 +544,7 @@ func TestReconnectVerbose(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.Verbose = true
 	rch := make(chan bool)
 	o.ReconnectedCB = func(_ *nats.Conn) {
@@ -580,7 +580,7 @@ func TestReconnectBufSize(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	o := nats.DefaultOptions
+	o := nats.GetDefaultOptions()
 	o.ReconnectBufSize = 32 // 32 bytes
 
 	dch := make(chan bool)

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -505,7 +505,7 @@ func TestAsyncErrHandler(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 
 	nc, err := opts.Connect()
 	if err != nil {
@@ -584,7 +584,7 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	opts := nats.DefaultOptions
+	opts := nats.GetDefaultOptions()
 
 	nc, err := opts.Connect()
 	if err != nil {


### PR DESCRIPTION
At the moment DefaultOptions is a global struct that is being copied by value. Some of the fields are pointers, so they got copied as well while retaining their value and thus making these fields effectively global. This breaks logic of multiple operations with DefaultOptions which may be modified by other users (e.g. in tests).
This PR is making it a function that returns a fresh copy of DefaultOptions each time to use independently.