### PR TITLE
[REMOVED] Dialer from DefaultOptions

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -79,8 +79,9 @@ var (
 	ErrStaleConnection      = errors.New("nats: " + STALE_CONNECTION)
 )
 
+// GetDefaultOptions returns default configuration options for the client.
 func GetDefaultOptions() Options {
-	opts := Options{
+	return Options{
 		AllowReconnect:   true,
 		MaxReconnect:     DefaultMaxReconnect,
 		ReconnectWait:    DefaultReconnectWait,
@@ -89,11 +90,7 @@ func GetDefaultOptions() Options {
 		MaxPingsOut:      DefaultMaxPingOut,
 		SubChanLen:       DefaultMaxChanLen,
 		ReconnectBufSize: DefaultReconnectBufSize,
-		Dialer: &net.Dialer{
-			Timeout: DefaultTimeout,
-		},
 	}
-	return opts
 }
 
 // DEPRECATED: Use GetDefaultOptions() instead.

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1312,6 +1312,30 @@ func TestUseCustomDialer(t *testing.T) {
 	}
 }
 
+func TestDefaultOptionsDialer(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	opts1 := nats.DefaultOptions
+	opts2 := nats.DefaultOptions
+
+	nc1, err := opts1.Connect()
+	if err != nil {
+		t.Fatalf("Unexpected error on connect: %v", err)
+	}
+	defer nc1.Close()
+
+	nc2, err := opts2.Connect()
+	if err != nil {
+		t.Fatalf("Unexpected error on connect: %v", err)
+	}
+	defer nc2.Close()
+
+	if nc1.Opts.Dialer == nc2.Opts.Dialer {
+		t.Fatalf("Expected each connection to have its own dialer")
+	}
+}
+
 func TestCustomFlusherTimeout(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()


### PR DESCRIPTION
(Follow up from PR: https://github.com/nats-io/go-nats/pull/308)

As part of commit (https://github.com/nats-io/go-nats/commit/c46810140b837ae134c6f47930ea7226691c77b4) it was added the option to be able to set a custom [Dialer](https://golang.org/pkg/net/#Dialer) on the client, but it was also included a default one as part of `nats.DefaultOptions` which was not necessary since one would have been created on connect if it was not set anyway: https://github.com/nats-io/go-nats/blob/7488b993f3f8b09249686708910f052694ef0a5a/nats.go#L683-L688

This removes `Dialer` from being part of the `nats.DefaultOptions` to only leave constants which can't be changed as part of the options, in order to prevent multiple connections sharing the same dialer because of borrowing the same one via the `DefaultOptions`.
