### PR TITLE
Use the latest version of Go in Travis.CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 sudo: false
 go:
-- 1.8.3
-- 1.7.6
-- 1.6.4
+- 1.8.x
+- 1.7.x
+- 1.6.x
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd


### PR DESCRIPTION
Travis.CI support `x`  in place of the minor to use the latest for a given major version - https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use