### PR TITLE
Use Fprintf instead of Sprintf+WriteString

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2248,7 +2248,7 @@ func (nc *Conn) subscribe(subj, queue string, cb MsgHandler, ch chan *Msg) (*Sub
 	// We will send these for all subs when we reconnect
 	// so that we can suppress here.
 	if !nc.isReconnecting() {
-		nc.bw.WriteString(fmt.Sprintf(subProto, subj, queue, sub.sid))
+		fmt.Fprintf(nc.bw, subProto, subj, queue, sub.sid)
 	}
 	return sub, nil
 }
@@ -2368,7 +2368,7 @@ func (nc *Conn) unsubscribe(sub *Subscription, max int) error {
 	// We will send these for all subs when we reconnect
 	// so that we can suppress here.
 	if !nc.isReconnecting() {
-		nc.bw.WriteString(fmt.Sprintf(unsubProto, s.sid, maxStr))
+		fmt.Fprintf(nc.bw, unsubProto, s.sid, maxStr)
 	}
 	return nil
 }
@@ -2732,16 +2732,16 @@ func (nc *Conn) resendSubscriptions() {
 			// reached the max, if so unsubscribe.
 			if adjustedMax == 0 {
 				s.mu.Unlock()
-				nc.bw.WriteString(fmt.Sprintf(unsubProto, s.sid, _EMPTY_))
+				fmt.Fprintf(nc.bw, unsubProto, s.sid, _EMPTY_)
 				continue
 			}
 		}
 		s.mu.Unlock()
 
-		nc.bw.WriteString(fmt.Sprintf(subProto, s.Subject, s.Queue, s.sid))
+		fmt.Fprintf(nc.bw, subProto, s.Subject, s.Queue, s.sid)
 		if adjustedMax > 0 {
 			maxStr := strconv.Itoa(int(adjustedMax))
-			nc.bw.WriteString(fmt.Sprintf(unsubProto, s.sid, maxStr))
+			fmt.Fprintf(nc.bw, unsubProto, s.sid, maxStr)
 		}
 	}
 }


### PR DESCRIPTION
No performance change, but avoids one allocation when (un)subscribing.

```
name                              old alloc/op   new alloc/op   delta
PublishSpeed-8                       0.00B          0.00B          ~     (all equal)
PubSubSpeed-8                         122B ± 0%      121B ± 0%   -1.14%  (p=0.000 n=5+4)
AsyncSubscriptionCreationSpeed-8    1.02kB ±28%    1.00kB ±28%     ~     (p=0.643 n=5+5)
SyncSubscriptionCreationSpeed-8     66.3kB ± 0%    66.3kB ± 0%   -0.02%  (p=0.008 n=5+5)
InboxCreation-8                      64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Request-8                             693B ± 0%      693B ± 0%     ~     (p=1.000 n=4+5)
OldRequest-8                        2.44kB ± 0%    2.37kB ± 0%   -2.63%  (p=0.029 n=4+4)
PublishGobStruct-8                  14.1kB ± 0%    14.1kB ± 0%     ~     (p=0.921 n=5+5)
JsonMarshalStruct-8                   992B ± 0%      992B ± 0%     ~     (all equal)
PublishJsonStruct-8                 3.78kB ± 0%    3.78kB ± 0%     ~     (p=1.000 n=4+4)
PublishSpeedViaChan-8                 169B ± 0%      169B ± 0%     ~     (all equal)
ProtobufMarshalStruct-8               712B ± 0%      712B ± 0%     ~     (all equal)
PublishProtobufStruct-8             2.70kB ± 1%    2.71kB ± 1%     ~     (p=0.629 n=4+4)

name                              old allocs/op  new allocs/op  delta
PublishSpeed-8                        0.00           0.00          ~     (all equal)
PubSubSpeed-8                         3.00 ± 0%      3.00 ± 0%     ~     (all equal)
AsyncSubscriptionCreationSpeed-8      12.0 ± 0%      11.0 ± 0%   -8.33%  (p=0.029 n=4+4)
SyncSubscriptionCreationSpeed-8       12.0 ± 0%      11.0 ± 0%   -8.33%  (p=0.008 n=5+5)
InboxCreation-8                       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Request-8                             14.0 ± 0%      14.0 ± 0%     ~     (all equal)
OldRequest-8                          52.0 ± 0%      50.0 ± 0%   -3.85%  (p=0.008 n=5+5)
PublishGobStruct-8                     330 ± 0%       330 ± 0%     ~     (all equal)
JsonMarshalStruct-8                   11.0 ± 0%      11.0 ± 0%     ~     (all equal)
PublishJsonStruct-8                   66.0 ± 0%      66.0 ± 0%     ~     (all equal)
PublishSpeedViaChan-8                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
ProtobufMarshalStruct-8               14.0 ± 0%      14.0 ± 0%     ~     (all equal)
PublishProtobufStruct-8               66.0 ± 0%      66.0 ± 0%     ~     (all equal)
```