### PR TITLE
Removed nats RootCAs redundant type conversion of rootPEM and fixed typo 

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1040,7 +1040,7 @@ func (nc *Conn) connect() error {
 	// to connect immediately.
 	nc.mu.Lock()
 	nc.initc = true
-	// The pool may change inside theloop iteration due to INFO protocol.
+	// The pool may change inside the loop iteration due to INFO protocol.
 	for i := 0; i < len(nc.srvPool); i++ {
 		nc.url = nc.srvPool[i].url
 

--- a/nats.go
+++ b/nats.go
@@ -787,7 +787,7 @@ const tlsScheme = "tls"
 
 // Create the server pool using the options given.
 // We will place a Url option first, followed by any
-// Server Options. We will randomize the server pool unlesss
+// Server Options. We will randomize the server pool unless
 // the NoRandomize flag is set.
 func (nc *Conn) setupServerPool() error {
 	nc.srvPool = make([]*srv, 0, srvPoolSize)

--- a/nats.go
+++ b/nats.go
@@ -450,7 +450,7 @@ func RootCAs(file ...string) Option {
 			if err != nil || rootPEM == nil {
 				return fmt.Errorf("nats: error loading or parsing rootCA file: %v", err)
 			}
-			ok := pool.AppendCertsFromPEM([]byte(rootPEM))
+			ok := pool.AppendCertsFromPEM(rootPEM)
 			if !ok {
 				return fmt.Errorf("nats: failed to parse root certificate from %q", f)
 			}


### PR DESCRIPTION
Removed nats RootCAs redundant type conversion of rootPEM. ioutil.ReadFile returns []byte, and err. There is no need to typecast rootPEM to []byte since it's already in bytes if there is no error. 

Fixed typo in nats setupServerPool method description

Fixed nats connect comment word spacing.