### PR TITLE
[FIXED] ErrorHandler not always reporting proper error

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1682,9 +1682,11 @@ slowConsumer:
 // permissions violation on either publish or subscribe.
 func (nc *Conn) processPermissionsViolation(err string) {
 	nc.mu.Lock()
-	nc.err = errors.New("nats: " + err)
+	// create error here so we can pass it as a closure to the async cb dispatcher.
+	e := errors.New("nats: " + err)
+	nc.err = e
 	if nc.Opts.AsyncErrorCB != nil {
-		nc.ach <- func() { nc.Opts.AsyncErrorCB(nc, nil, nc.err) }
+		nc.ach <- func() { nc.Opts.AsyncErrorCB(nc, nil, e) }
 	}
 	nc.mu.Unlock()
 }

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -185,11 +185,9 @@ func TestPermViolation(t *testing.T) {
 	s := RunServerWithOptions(opts)
 	defer s.Shutdown()
 
-	ch := make(chan bool)
+	errCh := make(chan error, 2)
 	errCB := func(_ *nats.Conn, _ *nats.Subscription, err error) {
-		if strings.Contains(err.Error(), nats.PERMISSIONS_ERR) {
-			ch <- true
-		}
+		errCh <- err
 	}
 	nc, err := nats.Connect(
 		fmt.Sprintf("nats://ivan:pwd@localhost:%d", opts.Port),
@@ -198,22 +196,26 @@ func TestPermViolation(t *testing.T) {
 		t.Fatalf("Error on connect: %v", err)
 	}
 	defer nc.Close()
-	for i := 0; i < 2; i++ {
-		switch i {
-		case 0:
-			// Cause a publish error
-			nc.Publish("bar", []byte("fail"))
-		case 1:
-			// Cause a subscribe error
-			nc.Subscribe("foo", func(_ *nats.Msg) {})
+
+	// Cause a publish error
+	nc.Publish("bar", []byte("fail"))
+	// Cause a subscribe error
+	nc.Subscribe("foo", func(_ *nats.Msg) {})
+
+	expectedErrorTypes := []string{"publish", "subscription"}
+	for _, expectedErr := range expectedErrorTypes {
+		select {
+		case e := <-errCh:
+			if !strings.Contains(e.Error(), nats.PERMISSIONS_ERR) {
+				t.Fatalf("Did not receive error about permissions")
+			}
+			if !strings.Contains(e.Error(), expectedErr) {
+				t.Fatalf("Did not receive error about %q, got %v", expectedErr, e.Error())
+			}
 		}
-		// We should get the async error cb
-		if err := Wait(ch); err != nil {
-			t.Fatal("Did not get our callback")
-		}
-		// Make sure connection has not been closed
-		if nc.IsClosed() {
-			t.Fatal("Connection should be not be closed")
-		}
+	}
+	// Make sure connection has not been closed
+	if nc.IsClosed() {
+		t.Fatal("Connection should be not be closed")
 	}
 }

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -212,6 +212,8 @@ func TestPermViolation(t *testing.T) {
 			if !strings.Contains(e.Error(), expectedErr) {
 				t.Fatalf("Did not receive error about %q, got %v", expectedErr, e.Error())
 			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Did not get the permission error")
 		}
 	}
 	// Make sure connection has not been closed


### PR DESCRIPTION
The issue was that we were using `nc.err` as a parameter of
the closure function sent to `nc.ach`. The value of the error
would then change and be whatever last value is.
We now create an error so that this is unique per scheduled
async error.

Updated the test that checks not only that we get the permission
violation error, but that we get the expected one (one for sub
and for for pub).

Resolves #325