### PR TITLE
Resize pending pongs slice when flush times out

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -2616,7 +2616,10 @@ func (nc *Conn) removeFlushEntry(ch chan struct{}) bool {
 	}
 	for i, c := range nc.pongs {
 		if c == ch {
-			nc.pongs[i] = nil
+			// Swap entry to be removed with the one at the beginning,
+			// then resize the list to discard it.
+			nc.pongs[i], nc.pongs[0] = nc.pongs[0], nil
+			nc.pongs = nc.pongs[1:]
 			return true
 		}
 	}


### PR DESCRIPTION
When a `Flush` call has timed out, the channel awaiting the pong reply is changed to be nil but it is not dropped from the pending pongs slice, so it can continue to grow for the same connection.  This can occur when the client is attempting to flush during the reconnection state for example.