### PR TITLE
[ADDED] ReconnectBufSize() Option function

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -535,6 +535,14 @@ func MaxReconnects(max int) Option {
 	}
 }
 
+// ReconnectBufSize sets the buffer size of messages kept while busy reconnecting
+func ReconnectBufSize(size int) Option {
+	return func(o *Options) error {
+		o.ReconnectBufSize = size
+		return nil
+	}
+}
+
 // Timeout is an Option to set the timeout for Dial on a connection.
 func Timeout(t time.Duration) Option {
 	return func(o *Options) error {
@@ -575,7 +583,7 @@ func DiscoveredServersHandler(cb ConnHandler) Option {
 	}
 }
 
-// ErrHandler is an Option to set the async error  handler.
+// ErrorHandler is an Option to set the async error  handler.
 func ErrorHandler(cb ErrHandler) Option {
 	return func(o *Options) error {
 		o.AsyncErrorCB = cb
@@ -622,7 +630,7 @@ func SetCustomDialer(dialer CustomDialer) Option {
 	}
 }
 
-// UseOldRequestyStyle is an Option to force usage of the old Request style.
+// UseOldRequestStyle is an Option to force usage of the old Request style.
 func UseOldRequestStyle() Option {
 	return func(o *Options) error {
 		o.UseOldRequestStyle = true
@@ -672,7 +680,7 @@ func (nc *Conn) SetClosedHandler(cb ConnHandler) {
 	nc.Opts.ClosedCB = cb
 }
 
-// SetErrHandler will set the async error handler.
+// SetErrorHandler will set the async error handler.
 func (nc *Conn) SetErrorHandler(cb ErrHandler) {
 	if nc == nil {
 		return

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -700,8 +700,7 @@ func TestCallbacksOrder(t *testing.T) {
 		nats.ClosedHandler(cch),
 		nats.ErrorHandler(ech),
 		nats.ReconnectWait(50*time.Millisecond),
-		nats.DontRandomize(),
-		nats.ReconnectBufSize(10*1024))
+		nats.DontRandomize())
 
 	if err != nil {
 		t.Fatalf("Unable to connect: %v\n", err)

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -700,7 +700,9 @@ func TestCallbacksOrder(t *testing.T) {
 		nats.ClosedHandler(cch),
 		nats.ErrorHandler(ech),
 		nats.ReconnectWait(50*time.Millisecond),
-		nats.DontRandomize())
+		nats.DontRandomize(),
+		nats.ReconnectBufSize(10*1024))
+
 	if err != nil {
 		t.Fatalf("Unable to connect: %v\n", err)
 	}

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -576,6 +576,21 @@ func TestReconnectVerbose(t *testing.T) {
 	}
 }
 
+func TestReconnectBufSizeOption(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	nc, err := nats.Connect("nats://localhost:4222", nats.ReconnectBufSize(32))
+	if err != nil {
+		t.Fatalf("Should have connected ok: %v", err)
+	}
+	defer nc.Close()
+
+	if nc.Opts.ReconnectBufSize != 32 {
+		t.Fatalf("ReconnectBufSize should be 32 but it is %d", nc.Opts.ReconnectBufSize)
+	}
+}
+
 func TestReconnectBufSize(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()


### PR DESCRIPTION
This creates a function one can use to set the ReconnectBufSize option,
it's similar in design to the other functions already here

Also makes small fixes to some doc strings that I noticed