### PR TITLE
[IMPROVED] Reuse buffers in Conn.processOpError

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1475,10 +1475,12 @@ func (nc *Conn) processOpErr(err error) {
 			nc.conn = nil
 		}
 
-		// Create a new pending buffer to underpin the bufio Writer while
-		// we are reconnecting.
-		nc.pending = &bytes.Buffer{}
-		nc.bw = bufio.NewWriterSize(nc.pending, nc.Opts.ReconnectBufSize)
+		// Reset pending buffers before reconnecting.
+		if nc.pending == nil {
+			nc.pending = new(bytes.Buffer)
+		}
+		nc.pending.Reset()
+		nc.bw.Reset(nc.pending)
 
 		go nc.doReconnect()
 		nc.mu.Unlock()


### PR DESCRIPTION
This significantly reduces memory usage when the nats Conn enters an error loop.

In a Cloud Foundry test ([route-emitter/cmd/route-emitter](https://github.com/cloudfoundry/route-emitter/blob/master/cmd/route-emitter/main_test.go)) the `Conn.processOpError` was responsible for ~95% of memory allocations.  This was due to `Conn.processOpError` allocating a new `bufio.Writer` each time it was called.  This commit changes `Conn.processOpError` to reuse and reset its existing `bufio.Writer`.

Below is the output from `go tool pprof` implicating `Conn.processOpError`:

```
File: route-emitter.test
Type: inuse_space
Time: Feb 17, 2018 at 5:54pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top5 -cum
Showing nodes accounting for 560MB, 94.65% of 591.68MB total
Dropped 30 nodes (cum <= 2.96MB)
Showing top 5 nodes out of 11
      flat  flat%   sum%        cum   cum%
         0     0%     0%   563.50MB 95.24%  github.com/nats-io/nats.(*Conn).readLoop
     560MB 94.65% 94.65%      560MB 94.65%  github.com/nats-io/nats.(*Conn).processOpErr
         0     0% 94.65%    25.67MB  4.34%  io.(*multiWriter).Write
         0     0% 94.65%    25.67MB  4.34%  io.Copy
         0     0% 94.65%    25.67MB  4.34%  io.copyBuffer
```

Output of `go tool pprof` after applying this patch (note the absence of `nats-io` and overall reduction in memory):

```
File: route-emitter.test
Type: inuse_space
Time: Feb 17, 2018 at 6:54pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top5 -cum
Showing nodes accounting for 0, 0% of 31.14MB total
Showing top 5 nodes out of 90
      flat  flat%   sum%        cum   cum%
         0     0%     0%    21.88MB 70.28%  io.(*multiWriter).Write
         0     0%     0%    21.88MB 70.28%  io.Copy
         0     0%     0%    21.88MB 70.28%  io.copyBuffer
         0     0%     0%    21.88MB 70.28%  os/exec.(*Cmd).Start.func1
         0     0%     0%    21.88MB 70.28%  os/exec.(*Cmd).writerDescriptor.func1
```

I would have provided the output of running the benchmarks in [nats-io/go-nats/test](https://github.com/nats-io/go-nats/tree/master/test), but they do not appear to hit this code path.  That said, I'd be happy to send them if you think they'd be useful.