### PR TITLE
nats: simplify error check in Conn.connect

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -15,7 +15,6 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1109,7 +1108,7 @@ func (nc *Conn) connect() error {
 		} else {
 			// Cancel out default connection refused, will trigger the
 			// No servers error conditional
-			if matched, _ := regexp.Match(`connection refused`, []byte(err.Error())); matched {
+			if strings.Contains(err.Error(), "connection refused") {
 				returnedErr = nil
 			}
 		}


### PR DESCRIPTION
This commit replaces the regex used to check for the string literal
'connection refused' with strings.Contains in `Conn.connect`. Using
regexp.Match requires compiling the regex on each call - since the
string being matched is a literal strings.Contains is a simpler and
more performant option here.