### PR TITLE
[IMPROVED] Server pool is updated based on server notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 sudo: false
 go:
+- 1.10.x
 - 1.9.x
 - 1.8.x
-- 1.7.x
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
@@ -18,4 +18,4 @@ before_script:
 - megacheck -ignore "$(cat staticcheck.ignore)" ./...
 script:
 - go test -i -race ./... 
-- if [[ "$TRAVIS_GO_VERSION" == 1.7.* ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race ./...; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.9.* ]]; then ./scripts/cov.sh TRAVIS; else go test -v -race ./...; fi

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"fmt"
 	"math"
+	"net"
 	"regexp"
 	"runtime"
 	"strings"
@@ -9,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats"
 )
@@ -24,6 +27,17 @@ var testServers = []string{
 }
 
 var servers = strings.Join(testServers, ",")
+
+func serverVersionAtLeast(major, minor, update int) error {
+	var (
+		ma, mi, up int
+	)
+	fmt.Sscanf(server.VERSION, "%d.%d.%d", &ma, &mi, &up)
+	if ma > major || (ma == major && mi > minor) || (ma == major && mi == minor && up >= update) {
+		return nil
+	}
+	return fmt.Errorf("Server version is %v, requires %d.%d.%d+", server.VERSION, major, minor, update)
+}
 
 func TestServersOption(t *testing.T) {
 	opts := nats.GetDefaultOptions()
@@ -603,4 +617,229 @@ func TestPingReconnect(t *testing.T) {
 			t.Fatalf("Reconnect due to ping took %s", pingCycle.String())
 		}
 	}
+}
+
+type checkPoolUpdatedDialer struct {
+	conn         net.Conn
+	first, final bool
+	ra           int
+}
+
+func (d *checkPoolUpdatedDialer) Dial(network, address string) (net.Conn, error) {
+	doReal := false
+	if d.first {
+		d.first = false
+		doReal = true
+	} else if d.final {
+		d.ra++
+		return nil, fmt.Errorf("On purpose")
+	} else {
+		d.ra++
+		if d.ra == 15 {
+			d.ra = 0
+			doReal = true
+		}
+	}
+	if doReal {
+		c, err := net.Dial(network, address)
+		if err != nil {
+			return nil, err
+		}
+		d.conn = c
+		return c, nil
+	}
+	return nil, fmt.Errorf("On purpose")
+}
+
+func TestServerPoolUpdatedWhenRouteGoesAway(t *testing.T) {
+	if err := serverVersionAtLeast(1, 0, 6); err != nil {
+		t.Skipf(err.Error())
+	}
+	s1Opts := test.DefaultTestOptions
+	s1Opts.Host = "127.0.0.1"
+	s1Opts.Port = 4222
+	s1Opts.Cluster.Host = "127.0.0.1"
+	s1Opts.Cluster.Port = 6222
+	s1Opts.Routes = server.RoutesFromStr("nats://127.0.0.1:6223,nats://127.0.0.1:6224")
+	s1 := test.RunServer(&s1Opts)
+	defer s1.Shutdown()
+
+	s1Url := "nats://127.0.0.1:4222"
+	s2Url := "nats://127.0.0.1:4223"
+	s3Url := "nats://127.0.0.1:4224"
+
+	ch := make(chan bool, 1)
+	chch := make(chan bool, 1)
+	connHandler := func(_ *nats.Conn) {
+		chch <- true
+	}
+	nc, err := nats.Connect(s1Url,
+		nats.ReconnectHandler(connHandler),
+		nats.DiscoveredServersHandler(func(_ *nats.Conn) {
+			ch <- true
+		}))
+	if err != nil {
+		t.Fatalf("Error on connect")
+	}
+
+	s2Opts := test.DefaultTestOptions
+	s2Opts.Host = "127.0.0.1"
+	s2Opts.Port = s1Opts.Port + 1
+	s2Opts.Cluster.Host = "127.0.0.1"
+	s2Opts.Cluster.Port = 6223
+	s2Opts.Routes = server.RoutesFromStr("nats://127.0.0.1:6222,nats://127.0.0.1:6224")
+	s2 := test.RunServer(&s2Opts)
+	defer s2.Shutdown()
+
+	// Wait to be notified
+	if err := Wait(ch); err != nil {
+		t.Fatal("New server callback was not invoked")
+	}
+
+	checkPool := func(expected []string) {
+		// Don't use discovered here, but Servers to have the full list.
+		// Also, there may be cases where the mesh is not formed yet,
+		// so try again on failure.
+		var (
+			ds      []string
+			timeout = time.Now().Add(3 * time.Second)
+		)
+		for time.Now().Before(timeout) {
+		startCheck:
+			ds = nc.Servers()
+			if len(ds) == len(expected) {
+				m := make(map[string]struct{}, len(ds))
+				for _, url := range ds {
+					m[url] = struct{}{}
+				}
+				for _, url := range expected {
+					if _, present := m[url]; !present {
+						time.Sleep(15 * time.Millisecond)
+						goto startCheck
+					}
+				}
+				// we are good
+				return
+			}
+		}
+		stackFatalf(t, "Expected %v, got %v", expected, ds)
+	}
+	// Verify that we now know about s2
+	checkPool([]string{s1Url, s2Url})
+
+	s3Opts := test.DefaultTestOptions
+	s3Opts.Host = "127.0.0.1"
+	s3Opts.Port = s2Opts.Port + 1
+	s3Opts.Cluster.Host = "127.0.0.1"
+	s3Opts.Cluster.Port = 6224
+	s3Opts.Routes = server.RoutesFromStr("nats://127.0.0.1:6222,nats://127.0.0.1:6223")
+	s3 := test.RunServer(&s3Opts)
+	defer s3.Shutdown()
+
+	// Wait to be notified
+	if err := Wait(ch); err != nil {
+		t.Fatal("New server callback was not invoked")
+	}
+	// Verify that we now know about s3
+	checkPool([]string{s1Url, s2Url, s3Url})
+
+	// Stop s1. Since this was passed to the Connect() call, this one should
+	// still be present.
+	s1.Shutdown()
+	// Wait for reconnect
+	if err := Wait(chch); err != nil {
+		t.Fatal("Reconnect handler not invoked")
+	}
+	checkPool([]string{s1Url, s2Url, s3Url})
+
+	// Check the server we reconnected to.
+	reConnectedTo := nc.ConnectedUrl()
+	expected := []string{s1Url}
+	restartS2 := false
+	if reConnectedTo == s2Url {
+		restartS2 = true
+		s2.Shutdown()
+		expected = append(expected, s3Url)
+	} else if reConnectedTo == s3Url {
+		s3.Shutdown()
+		expected = append(expected, s2Url)
+	} else {
+		t.Fatalf("Unexpected server client has reconnected to: %v", reConnectedTo)
+	}
+	// Wait for reconnect
+	if err := Wait(chch); err != nil {
+		t.Fatal("Reconnect handler not invoked")
+	}
+	// The implicit server that we just shutdown should have been removed from the pool
+	checkPool(expected)
+
+	// Restart the one that was shutdown and check that it is now back in the pool
+	if restartS2 {
+		s2 = test.RunServer(&s2Opts)
+		defer s2.Shutdown()
+		expected = append(expected, s2Url)
+	} else {
+		s3 = test.RunServer(&s3Opts)
+		defer s3.Shutdown()
+		expected = append(expected, s3Url)
+	}
+	// Since this is not a "new" server, the DiscoveredServersCB won't be invoked.
+	checkPool(expected)
+
+	nc.Close()
+
+	// Restart s1
+	s1 = test.RunServer(&s1Opts)
+	defer s1.Shutdown()
+
+	// We should have all 3 servers running now...
+
+	// Create a client connection with special dialer.
+	d := &checkPoolUpdatedDialer{first: true}
+	nc, err = nats.Connect(s1Url,
+		nats.MaxReconnects(10),
+		nats.ReconnectWait(15*time.Millisecond),
+		nats.SetCustomDialer(d),
+		nats.ReconnectHandler(connHandler),
+		nats.ClosedHandler(connHandler))
+	if err != nil {
+		t.Fatalf("Error on connect")
+	}
+	defer nc.Close()
+
+	// Make sure that we have all 3 servers in the pool (this will wait if required)
+	checkPool(expected)
+
+	// Cause disconnection between client and server. We are going to reconnect
+	// and we want to check that when we get the INFO again with the list of
+	// servers, we don't lose the knowledge of how many times we tried to
+	// reconnect.
+	d.conn.Close()
+
+	// Wait for client to reconnect to a server
+	if err := Wait(chch); err != nil {
+		t.Fatal("Reconnect handler not invoked")
+	}
+	// At this point, we should have tried to reconnect 5 times to each server.
+	// For the one we reconnected to, its max reconnect attempts should have been
+	// cleared, not for the other ones.
+
+	// Cause a disconnect again and ensure we won't reconnect.
+	d.final = true
+	d.conn.Close()
+
+	// Wait for Close callback to be invoked.
+	if err := Wait(chch); err != nil {
+		t.Fatal("Close handler not invoked")
+	}
+
+	// Since MaxReconnect is 10, after trying 5 more times on 2 of the servers,
+	// these should have been removed. We have still 5 more tries for the server
+	// we did previously reconnect to.
+	// So total of reconnect attempt should be: 2*5+1*10=20
+	if d.ra != 20 {
+		t.Fatalf("Should have tried to reconnect 20 more times, got %v", d.ra)
+	}
+
+	nc.Close()
 }


### PR DESCRIPTION
The server pool was only growing when new servers were discovered.
Now, the client library updates its server pool based on server's
INFO protocols (true for server 1.0.6+).
The DiscoveredServersCB is still invoked only when new servers
are added (as in never seen as opposed to added back after leaving
the cluster).

The code should work ok with older servers but will take advantage
of changes in the server (https://github.com/nats-io/gnatsd/pull/626)