### PR TITLE
Fixed locking in Barrier when there is no async subscription

### DIFF
--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1743,4 +1743,18 @@ func TestBarrier(t *testing.T) {
 	if err := nc.Barrier(func() { ch <- true }); err != nats.ErrConnectionClosed {
 		t.Fatalf("Expected error %v, got %v", nats.ErrConnectionClosed, err)
 	}
+
+	// Check that one can call connection methods from Barrier
+	// when there is no async subscriptions
+	nc = NewDefaultConnection(t)
+	defer nc.Close()
+
+	if err := nc.Barrier(func() {
+		ch <- nc.TLSRequired()
+	}); err != nil {
+		t.Fatalf("Error on Barrier: %v", err)
+	}
+	if err := Wait(ch); err != nil {
+		t.Fatal("Barrier was blocked")
+	}
 }


### PR DESCRIPTION
I originally started `f` as a go routine, but decided not to, however doing so I should have released the locks. This is done now.

Related to #338 
Resolves #345