### PR TITLE
[FIXED] Protocols received right after first PONG may be processed

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -1247,36 +1248,36 @@ func (nc *Conn) sendConnect() error {
 	// we would need to transfer the excess read data to the readLoop.
 	// Since in normal situations we just are looking for a PONG\r\n,
 	// reading byte-by-byte here is ok.
-	line, err := nc.readStringUpTo('\n')
+	proto, err := nc.readProto()
 	if err != nil {
 		return err
 	}
 
 	// If opts.Verbose is set, handle +OK
-	if nc.Opts.Verbose && line == okProto {
+	if nc.Opts.Verbose && proto == okProto {
 		// Read the rest now...
-		line, err = nc.readStringUpTo('\n')
+		proto, err = nc.readProto()
 		if err != nil {
 			return err
 		}
 	}
 
 	// We expect a PONG
-	if line != pongProto {
+	if proto != pongProto {
 		// But it could be something else, like -ERR
 
 		// Since we no longer use ReadLine(), trim the trailing "\r\n"
-		line = strings.TrimRight(line, "\r\n")
+		proto = strings.TrimRight(proto, "\r\n")
 
 		// If it's a server error...
-		if strings.HasPrefix(line, _ERR_OP_) {
+		if strings.HasPrefix(proto, _ERR_OP_) {
 			// Remove -ERR, trim spaces and quotes, and convert to lower case.
-			line = normalizeErr(line)
-			return errors.New("nats: " + line)
+			proto = normalizeErr(proto)
+			return errors.New("nats: " + proto)
 		}
 
 		// Notify that we got an unexpected protocol.
-		return fmt.Errorf("nats: expected '%s', got '%s'", _PONG_OP_, line)
+		return fmt.Errorf("nats: expected '%s', got '%s'", _PONG_OP_, proto)
 	}
 
 	// This is where we are truly connected.
@@ -1285,19 +1286,24 @@ func (nc *Conn) sendConnect() error {
 	return nil
 }
 
-// read byte-by-byte from the connection until the given 'c' character is found.
-func (nc *Conn) readStringUpTo(c byte) (string, error) {
+// reads a protocol one byte at a time.
+func (nc *Conn) readProto() (string, error) {
 	var (
-		_buf = [10]byte{}
-		buf  = _buf[:0]
-		b    = [1]byte{}
+		_buf     = [10]byte{}
+		buf      = _buf[:0]
+		b        = [1]byte{}
+		protoEnd = byte('\n')
 	)
 	for {
 		if _, err := nc.conn.Read(b[:1]); err != nil {
+			// Do not report EOF error
+			if err == io.EOF {
+				return string(buf), nil
+			}
 			return "", err
 		}
 		buf = append(buf, b[0])
-		if b[0] == c {
+		if b[0] == protoEnd {
 			return string(buf), nil
 		}
 	}

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1478,12 +1478,16 @@ func TestCustomFlusherTimeout(t *testing.T) {
 
 func TestNewServers(t *testing.T) {
 	s1Opts := test.DefaultTestOptions
+	s1Opts.Host = "127.0.0.1"
+	s1Opts.Port = 4222
 	s1Opts.Cluster.Host = "localhost"
 	s1Opts.Cluster.Port = 6222
 	s1 := test.RunServer(&s1Opts)
 	defer s1.Shutdown()
 
 	s2Opts := test.DefaultTestOptions
+	s2Opts.Host = "127.0.0.1"
+	s2Opts.Port = 4223
 	s2Opts.Port = s1Opts.Port + 1
 	s2Opts.Cluster.Host = "localhost"
 	s2Opts.Cluster.Port = 6223
@@ -1527,6 +1531,8 @@ func TestNewServers(t *testing.T) {
 
 	// Start a new server.
 	s3Opts := test.DefaultTestOptions
+	s1Opts.Host = "127.0.0.1"
+	s1Opts.Port = 4224
 	s3Opts.Port = s2Opts.Port + 1
 	s3Opts.Cluster.Host = "localhost"
 	s3Opts.Cluster.Port = 6224


### PR DESCRIPTION
This manifested with the recent changes where server may send
an async INFO protocol right after sending the initial PONG to
the client.
After the client sends the CONNECT protocol, it expects to receive
a PONG. The reading of the protocol is done in place (in the
sendConnect() function) but a buffer reader was used. This is wrong
since any data/protocol sent right after by the server may be
consumed when trying to read the PONG instead of leaving that to
the readLoop.
Since we are just looking for the PONG (or OK and PONG) here, perform
a byte-by-byte read there. Alternatively, if doing a buffered read,
the buffer will have to be passed to the readLoop so that whatever
is in the buffer is read prior to resuming reading from socket.