### PR TITLE
Added test ensuring version matches tag on new release

### DIFF
--- a/nats_test.go
+++ b/nats_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"runtime"
 	"strings"
@@ -62,6 +63,24 @@ func stackFatalf(t *testing.T, f string, args ...interface{}) {
 		lines = append(lines, msg)
 	}
 	t.Fatalf("%s", strings.Join(lines, "\n"))
+}
+
+func TestVersionMatchesTag(t *testing.T) {
+	tag := os.Getenv("TRAVIS_TAG")
+	if tag == "" {
+		t.SkipNow()
+	}
+	// We expect a tag of the form vX.Y.Z. If that's not the case,
+	// we need someone to have a look. So fail if first letter is not
+	// a `v`
+	if tag[0] != 'v' {
+		t.Fatalf("Expect tag to start with `v`, tag is: %s", tag)
+	}
+	// Strip the `v` from the tag for the version comparison.
+	tag = tag[1:]
+	if Version != tag {
+		t.Fatalf("Version (%s) does not match tag (%s)", Version, tag)
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Doing a new release by pushing a tag will allow a test to run and
verify that the library version matches the given tag.

```
git tag -a vX.Y.Z -m "Release vX.Y.Z"
git push --tags
```

If the test fails, then we would delete the newly created tag,
fix the version string and recreate the tag.