### PR TITLE
Create PingInterval helper function

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -546,6 +546,14 @@ func MaxReconnects(max int) Option {
 	}
 }
 
+// PingInterval is an Option to set the period for client ping commands
+func PingInterval(t time.Duration) Option {
+	return func(o *Options) error {
+		o.PingInterval = t
+		return nil
+	}
+}
+
 // ReconnectBufSize sets the buffer size of messages kept while busy reconnecting
 func ReconnectBufSize(size int) Option {
 	return func(o *Options) error {

--- a/test/basic_test.go
+++ b/test/basic_test.go
@@ -757,7 +757,11 @@ func TestOptions(t *testing.T) {
 	s := RunDefaultServer()
 	defer s.Shutdown()
 
-	nc, err := nats.Connect(nats.DefaultURL, nats.Name("myName"), nats.MaxReconnects(2), nats.ReconnectWait(50*time.Millisecond))
+	nc, err := nats.Connect(nats.DefaultURL,
+		nats.Name("myName"),
+		nats.MaxReconnects(2),
+		nats.ReconnectWait(50*time.Millisecond),
+		nats.PingInterval(20*time.Millisecond))
 	if err != nil {
 		t.Fatalf("Failed to connect: %v", err)
 	}


### PR DESCRIPTION
Related to https://github.com/nats-io/go-nats/issues/359 issue.

The new `PingInterval` function make it simpler to configure NATS connection. It's created similar way to `ReconnectWait` function. https://github.com/nats-io/go-nats/blob/master/nats.go#L534