### PR TITLE
run the mcb hook in parallel, instead of running one by one

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1657,7 +1657,7 @@ func (nc *Conn) waitForMsgs(s *Subscription) {
 
 		// Deliver the message.
 		if m != nil && (max == 0 || delivered <= max) {
-			mcb(m)
+			go mcb(m)
 		}
 		// If we have hit the max for delivered msgs, remove sub.
 		if max > 0 && delivered >= max {


### PR DESCRIPTION
from my point of view, the subscription handler should be run in parallel, like an http server, every time the 'api'(a publication in nats) is called, the handler should be called, instead of waiting for the last one to finish. Making the running of "mcb" as a golang coroutine satisfies this need. please make me informed if the change spoils something or it would cause some disaster :)