### PR TITLE
Support for Drain Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ msg := <- ch
 // Unsubscribe
 sub.Unsubscribe()
 
+// Drain
+sub.Drain()
+
 // Requests
 msg, err := nc.Request("help", []byte("help me"), 10*time.Millisecond)
 

--- a/nats.go
+++ b/nats.go
@@ -3341,7 +3341,7 @@ func (nc *Conn) isReconnecting() bool {
 
 // Test if Conn is connected or connecting.
 func (nc *Conn) isConnected() bool {
-	return nc.status == CONNECTED
+	return nc.status == CONNECTED || nc.isDraining()
 }
 
 // Test if Conn is in the draining state.

--- a/nats.go
+++ b/nats.go
@@ -3351,11 +3351,6 @@ func (nc *Conn) isDraining() bool {
 	return nc.status == DRAINING_SUBS || nc.status == DRAINING_PUBS
 }
 
-// Test if Conn is in the draining state for subs.
-func (nc *Conn) isDrainingSubs() bool {
-	return nc.status == DRAINING_SUBS
-}
-
 // Test if Conn is in the draining state for pubs.
 func (nc *Conn) isDrainingPubs() bool {
 	return nc.status == DRAINING_PUBS

--- a/nats.go
+++ b/nats.go
@@ -40,7 +40,7 @@ import (
 
 // Default Constants
 const (
-	Version                 = "1.6.0"
+	Version                 = "1.7.0"
 	DefaultURL              = "nats://localhost:4222"
 	DefaultPort             = 4222
 	DefaultMaxReconnect     = 60

--- a/nats_test.go
+++ b/nats_test.go
@@ -613,7 +613,6 @@ func TestParserShouldFail(t *testing.T) {
 }
 
 func TestParserSplitMsg(t *testing.T) {
-
 	nc := &Conn{}
 	nc.ps = &parseState{}
 

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -168,7 +167,7 @@ func TestAuthServers(t *testing.T) {
 		t.Fatalf("Expect Auth failure, got no error\n")
 	}
 
-	if matched, _ := regexp.Match(`authorization`, []byte(err.Error())); !matched {
+	if !strings.Contains(err.Error(), "authorization") {
 		t.Fatalf("Wrong error, wanted Auth failure, got '%s'\n", err)
 	}
 

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -32,7 +32,7 @@ func TestContextRequestWithNilConnection(t *testing.T) {
 
 	_, err := nc.RequestWithContext(ctx, "fast", []byte(""))
 	if err == nil {
-		t.Fatalf("Expected request with context and nil connection to fail\n")
+		t.Fatal("Expected request with context and nil connection to fail")
 	}
 	if err != nats.ErrInvalidConnection {
 		t.Fatalf("Expected nats.ErrInvalidConnection, got %v\n", err)
@@ -66,7 +66,7 @@ func testContextRequestWithTimeout(t *testing.T, nc *nats.Conn) {
 	// Slow request hits timeout so expected to fail.
 	_, err = nc.RequestWithContext(ctx, "slow", []byte("world"))
 	if err == nil {
-		t.Fatalf("Expected request with timeout context to fail: %s", err)
+		t.Fatal("Expected request with timeout context to fail")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -76,7 +76,7 @@ func testContextRequestWithTimeout(t *testing.T, nc *nats.Conn) {
 	}
 	timeoutErr, ok := err.(timeoutError)
 	if !ok || !timeoutErr.Timeout() {
-		t.Errorf("Expected to have a timeout error")
+		t.Error("Expected to have a timeout error")
 	}
 	expected = `context deadline exceeded`
 	if !strings.Contains(err.Error(), expected) {
@@ -87,7 +87,7 @@ func testContextRequestWithTimeout(t *testing.T, nc *nats.Conn) {
 	// has already timed out.
 	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
 	if err == nil {
-		t.Fatalf("Expected request with context to fail: %s", err)
+		t.Fatal("Expected request with context to fail")
 	}
 }
 
@@ -138,7 +138,7 @@ func testContextRequestWithTimeoutCanceled(t *testing.T, nc *nats.Conn) {
 
 	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
 	if err == nil {
-		t.Fatalf("Expected request with timeout context to fail: %s", err)
+		t.Fatal("Expected request with timeout context to fail")
 	}
 
 	// Reported error is "context canceled" from Context package,
@@ -157,7 +157,7 @@ func testContextRequestWithTimeoutCanceled(t *testing.T, nc *nats.Conn) {
 	// 2nd request should fail again even if fast because context has already been canceled
 	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))
 	if err == nil {
-		t.Fatalf("Expected request with context to fail: %s", err)
+		t.Fatal("Expected request with context to fail")
 	}
 }
 
@@ -238,7 +238,7 @@ func testContextRequestWithCancel(t *testing.T, nc *nats.Conn) {
 	// One more slow request will expire the timer and cause an error...
 	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
 	if err == nil {
-		t.Fatalf("Expected request with cancellation context to fail: %s", err)
+		t.Fatal("Expected request with cancellation context to fail")
 	}
 
 	// ...though reported error is "context canceled" from Context package,
@@ -305,7 +305,7 @@ func testContextRequestWithDeadline(t *testing.T, nc *nats.Conn) {
 	// reach the deadline.
 	_, err := nc.RequestWithContext(ctx, "slow", []byte(""))
 	if err == nil {
-		t.Fatalf("Expected request with context to reach deadline: %s", err)
+		t.Fatal("Expected request with context to reach deadline")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -383,7 +383,7 @@ func TestContextSubNextMsgWithTimeout(t *testing.T) {
 	// Third message will fail because the context will be canceled by now
 	_, err = sub.NextMsgWithContext(ctx)
 	if err == nil {
-		t.Fatalf("Expected to fail receiving a message: %s", err)
+		t.Fatal("Expected to fail receiving a message")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -440,7 +440,7 @@ func TestContextSubNextMsgWithTimeoutCanceled(t *testing.T) {
 
 	_, err = sub.NextMsgWithContext(ctx)
 	if err == nil {
-		t.Fatalf("Expected request with timeout context to fail: %s", err)
+		t.Fatal("Expected request with timeout context to fail")
 	}
 
 	// Reported error is "context canceled" from Context package,
@@ -515,7 +515,7 @@ func TestContextSubNextMsgWithCancel(t *testing.T) {
 	// cancel the context.
 	_, err = sub2.NextMsgWithContext(ctx)
 	if err == nil {
-		t.Fatalf("Expected request with context to fail: %s", err)
+		t.Fatal("Expected request with context to fail")
 	}
 
 	// Reported error is "context canceled" from Context package,
@@ -570,7 +570,7 @@ func TestContextSubNextMsgWithDeadline(t *testing.T) {
 	// Third message will fail because the context will be canceled by now
 	_, err = sub.NextMsgWithContext(ctx)
 	if err == nil {
-		t.Fatalf("Expected to fail receiving a message: %s", err)
+		t.Fatal("Expected to fail receiving a message")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -641,7 +641,7 @@ func TestContextEncodedRequestWithTimeout(t *testing.T) {
 	resp := &response{}
 	err = c.RequestWithContext(ctx, "slow", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with context to reach deadline: %s", err)
+		t.Fatal("Expected request with context to reach deadline")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -707,7 +707,7 @@ func TestContextEncodedRequestWithTimeoutCanceled(t *testing.T) {
 
 	err = c.RequestWithContext(ctx, "fast", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with timeout context to fail: %s", err)
+		t.Fatal("Expected request with timeout context to fail")
 	}
 
 	// Reported error is "context canceled" from Context package,
@@ -726,7 +726,7 @@ func TestContextEncodedRequestWithTimeoutCanceled(t *testing.T) {
 	// 2nd request should fail again even if fast because context has already been canceled
 	err = c.RequestWithContext(ctx, "fast", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with timeout context to fail: %s", err)
+		t.Fatal("Expected request with timeout context to fail")
 	}
 }
 
@@ -818,7 +818,7 @@ func TestContextEncodedRequestWithCancel(t *testing.T) {
 	// One more slow request will expire the timer and cause an error...
 	err = c.RequestWithContext(ctx, "slow", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with cancellation context to fail: %s", err)
+		t.Fatal("Expected request with cancellation context to fail")
 	}
 
 	// ...though reported error is "context canceled" from Context package,
@@ -888,7 +888,7 @@ func TestContextEncodedRequestWithDeadline(t *testing.T) {
 	resp := &response{}
 	err = c.RequestWithContext(ctx, "slow", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with context to reach deadline: %s", err)
+		t.Fatal("Expected request with context to reach deadline")
 	}
 
 	// Reported error is "context deadline exceeded" from Context package,
@@ -921,7 +921,7 @@ func TestContextRequestConnClosed(t *testing.T) {
 	nc.Close()
 	_, err := nc.RequestWithContext(ctx, "foo", []byte(""))
 	if err == nil {
-		t.Fatalf("Expected request to fail with error")
+		t.Fatal("Expected request to fail with error")
 	}
 	if err != nats.ErrConnectionClosed {
 		t.Errorf("Expected request to fail with connection closed error: %s", err)
@@ -952,7 +952,7 @@ func TestContextBadSubscription(t *testing.T) {
 
 	_, err = sub.NextMsgWithContext(ctx)
 	if err == nil {
-		t.Fatalf("Expected to fail getting next message with context")
+		t.Fatal("Expected to fail getting next message with context")
 	}
 
 	if err != nats.ErrBadSubscription {
@@ -973,7 +973,7 @@ func TestContextInvalid(t *testing.T) {
 
 	_, err = nc.RequestWithContext(nil, "foo", []byte(""))
 	if err == nil {
-		t.Fatalf("Expected request to fail with error")
+		t.Fatal("Expected request to fail with error")
 	}
 	if err != nats.ErrInvalidContext {
 		t.Errorf("Expected request to fail with connection closed error: %s", err)
@@ -986,7 +986,7 @@ func TestContextInvalid(t *testing.T) {
 
 	_, err = sub.NextMsgWithContext(nil)
 	if err == nil {
-		t.Fatalf("Expected request to fail with error")
+		t.Fatal("Expected request to fail with error")
 	}
 	if err != nats.ErrInvalidContext {
 		t.Errorf("Expected request to fail with connection closed error: %s", err)
@@ -1002,7 +1002,7 @@ func TestContextInvalid(t *testing.T) {
 	resp := &response{}
 	err = c.RequestWithContext(nil, "slow", req, resp)
 	if err == nil {
-		t.Fatalf("Expected request with context to reach deadline: %s", err)
+		t.Fatal("Expected request with context to reach deadline")
 	}
 	if err != nats.ErrInvalidContext {
 		t.Errorf("Expected request to fail with connection closed error: %s", err)

--- a/test/drain_test.go
+++ b/test/drain_test.go
@@ -249,7 +249,7 @@ func TestDrainConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create default connection: %v", err)
 	}
-	defer nc.Close()
+	defer nc2.Close()
 
 	received := int32(0)
 	responses := int32(0)

--- a/test/drain_test.go
+++ b/test/drain_test.go
@@ -1,0 +1,219 @@
+// Copyright 2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	nats "github.com/nats-io/go-nats"
+)
+
+// Drain can be very useful for graceful shutdown of subscribers.
+// Especially queue subscribers.
+func TestDrain(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	done := make(chan bool)
+	received := int32(0)
+	expected := int32(100)
+
+	cb := func(_ *nats.Msg) {
+		// Allow this to back up.
+		time.Sleep(time.Millisecond)
+		rcvd := atomic.AddInt32(&received, 1)
+		if rcvd >= expected {
+			done <- true
+		}
+	}
+
+	sub, err := nc.Subscribe("foo", cb)
+	if err != nil {
+		t.Fatalf("Error creating subscription; %v\n", err)
+	}
+
+	for i := int32(0); i < expected; i++ {
+		nc.Publish("foo", []byte("Don't forget about me"))
+	}
+
+	// Drain it and make sure we receive all messages.
+	sub.Drain()
+	select {
+	case <-done:
+		break
+	case <-time.After(2 * time.Second):
+		r := atomic.LoadInt32(&received)
+		if r != expected {
+			t.Fatalf("Did not receive all messages: %d of %d", r, expected)
+		}
+	}
+}
+
+func TestDrainQueueSub(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	done := make(chan bool)
+	received := int32(0)
+	expected := int32(4096)
+	numSubs := int32(32)
+
+	checkDone := func() int32 {
+		rcvd := atomic.AddInt32(&received, 1)
+		if rcvd >= expected {
+			done <- true
+		}
+		return rcvd
+	}
+
+	callback := func(m *nats.Msg) {
+		rcvd := checkDone()
+		// Randomly replace this sub from time to time.
+		if rcvd%3 == 0 {
+			m.Sub.Drain()
+			// Create a new one that we will not drain.
+			nc.QueueSubscribe("foo", "bar", func(m *nats.Msg) { checkDone() })
+		}
+	}
+
+	for i := int32(0); i < numSubs; i++ {
+		_, err := nc.QueueSubscribe("foo", "bar", callback)
+		if err != nil {
+			t.Fatalf("Error creating subscription; %v\n", err)
+		}
+	}
+
+	for i := int32(0); i < expected; i++ {
+		nc.Publish("foo", []byte("Don't forget about me"))
+	}
+
+	select {
+	case <-done:
+		break
+	case <-time.After(5 * time.Second):
+		r := atomic.LoadInt32(&received)
+		if r != expected {
+			t.Fatalf("Did not receive all messages: %d of %d", r, expected)
+		}
+	}
+}
+
+func waitFor(t *testing.T, totalWait, sleepDur time.Duration, f func() error) {
+	t.Helper()
+	timeout := time.Now().Add(totalWait)
+	var err error
+	for time.Now().Before(timeout) {
+		err = f()
+		if err == nil {
+			return
+		}
+		time.Sleep(sleepDur)
+	}
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestDrainUnSubs(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	num := 100
+	subs := make([]*nats.Subscription, num)
+
+	// Normal Unsubscribe
+	for i := 0; i < num; i++ {
+		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
+		if err != nil {
+			t.Fatalf("Error creating subscription; %v\n", err)
+		}
+		subs[i] = sub
+	}
+
+	if numSubs := nc.NumSubscriptions(); numSubs != num {
+		t.Fatalf("Expected %d subscriptions, got %d\n", num, numSubs)
+	}
+	for i := 0; i < num; i++ {
+		subs[i].Unsubscribe()
+	}
+	if numSubs := nc.NumSubscriptions(); numSubs != 0 {
+		t.Fatalf("Expected no subscriptions, got %d\n", numSubs)
+	}
+
+	// Drain version
+	for i := 0; i < num; i++ {
+		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
+		if err != nil {
+			t.Fatalf("Error creating subscription; %v\n", err)
+		}
+		subs[i] = sub
+	}
+
+	if numSubs := nc.NumSubscriptions(); numSubs != num {
+		t.Fatalf("Expected %d subscriptions, got %d\n", num, numSubs)
+	}
+	for i := 0; i < num; i++ {
+		subs[i].Drain()
+	}
+	// Should happen quickly that we get to zero, so do not need to wait long.
+	waitFor(t, 2*time.Second, 10*time.Millisecond, func() error {
+		if numSubs := nc.NumSubscriptions(); numSubs != 0 {
+			return fmt.Errorf("Expected no subscriptions, got %d\n", numSubs)
+		}
+		return nil
+	})
+}
+
+func TestDrainSlowSubscriber(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+	nc := NewDefaultConnection(t)
+	defer nc.Close()
+
+	sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {
+		time.Sleep(100 * time.Millisecond)
+	})
+	if err != nil {
+		t.Fatalf("Error creating subscription; %v\n", err)
+	}
+
+	total := 10
+
+	for i := 0; i < total; i++ {
+		nc.Publish("foo", []byte("Slow Slow"))
+	}
+
+	nc.Flush()
+	pmsgs, _, _ := sub.Pending()
+	if pmsgs != total && pmsgs != total-1 {
+		t.Fatalf("Expected most messages to be pending, but got %d vs %d\n", pmsgs, total)
+	}
+	// Should take a second or so to drain away.
+	waitFor(t, 2*time.Second, 100*time.Millisecond, func() error {
+		pmsgs, _, _ := sub.Pending()
+		if pmsgs != 0 {
+			return fmt.Errorf("Expected no pending, got %d\n", pmsgs)
+		}
+		return nil
+	})
+}

--- a/test/drain_test.go
+++ b/test/drain_test.go
@@ -45,7 +45,7 @@ func TestDrain(t *testing.T) {
 
 	sub, err := nc.Subscribe("foo", cb)
 	if err != nil {
-		t.Fatalf("Error creating subscription; %v\n", err)
+		t.Fatalf("Error creating subscription; %v", err)
 	}
 
 	for i := int32(0); i < expected; i++ {
@@ -97,7 +97,7 @@ func TestDrainQueueSub(t *testing.T) {
 	for i := int32(0); i < numSubs; i++ {
 		_, err := nc.QueueSubscribe("foo", "bar", callback)
 		if err != nil {
-			t.Fatalf("Error creating subscription; %v\n", err)
+			t.Fatalf("Error creating subscription; %v", err)
 		}
 	}
 
@@ -145,32 +145,32 @@ func TestDrainUnSubs(t *testing.T) {
 	for i := 0; i < num; i++ {
 		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
 		if err != nil {
-			t.Fatalf("Error creating subscription; %v\n", err)
+			t.Fatalf("Error creating subscription; %v", err)
 		}
 		subs[i] = sub
 	}
 
 	if numSubs := nc.NumSubscriptions(); numSubs != num {
-		t.Fatalf("Expected %d subscriptions, got %d\n", num, numSubs)
+		t.Fatalf("Expected %d subscriptions, got %d", num, numSubs)
 	}
 	for i := 0; i < num; i++ {
 		subs[i].Unsubscribe()
 	}
 	if numSubs := nc.NumSubscriptions(); numSubs != 0 {
-		t.Fatalf("Expected no subscriptions, got %d\n", numSubs)
+		t.Fatalf("Expected no subscriptions, got %d", numSubs)
 	}
 
 	// Drain version
 	for i := 0; i < num; i++ {
 		sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {})
 		if err != nil {
-			t.Fatalf("Error creating subscription; %v\n", err)
+			t.Fatalf("Error creating subscription; %v", err)
 		}
 		subs[i] = sub
 	}
 
 	if numSubs := nc.NumSubscriptions(); numSubs != num {
-		t.Fatalf("Expected %d subscriptions, got %d\n", num, numSubs)
+		t.Fatalf("Expected %d subscriptions, got %d", num, numSubs)
 	}
 	for i := 0; i < num; i++ {
 		subs[i].Drain()
@@ -197,7 +197,7 @@ func TestDrainSlowSubscriber(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	})
 	if err != nil {
-		t.Fatalf("Error creating subscription; %v\n", err)
+		t.Fatalf("Error creating subscription; %v", err)
 	}
 
 	total := 10
@@ -208,7 +208,7 @@ func TestDrainSlowSubscriber(t *testing.T) {
 
 	pmsgs, _, _ := sub.Pending()
 	if pmsgs != total && pmsgs != total-1 {
-		t.Fatalf("Expected most messages to be pending, but got %d vs %d\n", pmsgs, total)
+		t.Fatalf("Expected most messages to be pending, but got %d vs %d", pmsgs, total)
 	}
 	sub.Drain()
 
@@ -221,7 +221,7 @@ func TestDrainSlowSubscriber(t *testing.T) {
 		}
 		r := int(atomic.LoadInt32(&received))
 		if r != total {
-			t.Fatalf("Did not receive all messages, got %d vs %d\n", r, total)
+			t.Fatalf("Did not receive all messages, got %d vs %d", r, total)
 		}
 		return nil
 	})
@@ -241,13 +241,13 @@ func TestDrainConnection(t *testing.T) {
 	url := fmt.Sprintf("nats://127.0.0.1:%d", nats.DefaultPort)
 	nc, err := nats.Connect(url, nats.ClosedHandler(closed))
 	if err != nil {
-		t.Fatalf("Failed to create default connection: %v\n", err)
+		t.Fatalf("Failed to create default connection: %v", err)
 	}
 	defer nc.Close()
 
 	nc2, err := nats.Connect(url)
 	if err != nil {
-		t.Fatalf("Failed to create default connection: %v\n", err)
+		t.Fatalf("Failed to create default connection: %v", err)
 	}
 	defer nc.Close()
 
@@ -264,7 +264,7 @@ func TestDrainConnection(t *testing.T) {
 		}
 	})
 	if err != nil {
-		t.Fatalf("Error creating subscription for responses: %v\n", err)
+		t.Fatalf("Error creating subscription for responses: %v", err)
 	}
 
 	// Create a slow subscriber for the responder
@@ -277,7 +277,7 @@ func TestDrainConnection(t *testing.T) {
 		}
 	})
 	if err != nil {
-		t.Fatalf("Error creating subscription; %v\n", err)
+		t.Fatalf("Error creating subscription; %v", err)
 	}
 
 	// Publish some messages
@@ -290,16 +290,16 @@ func TestDrainConnection(t *testing.T) {
 
 	// Sub should be disabled immediately
 	if err := sub.Unsubscribe(); err == nil {
-		t.Fatalf("Expected to receive an error on Unsubscribe after drain\n")
+		t.Fatalf("Expected to receive an error on Unsubscribe after drain")
 	}
 	// Also can not create any new subs
 	if _, err := nc.Subscribe("foo", func(_ *nats.Msg) {}); err == nil {
-		t.Fatalf("Expected to receive an error on new Subscription after drain\n")
+		t.Fatalf("Expected to receive an error on new Subscription after drain")
 	}
 
 	// Make sure we can still publish, this is for any responses.
 	if err := nc.Publish("baz", []byte("Slow Slow")); err != nil {
-		t.Fatalf("Expected to not receive an error on Publish after drain, got %v\n", err)
+		t.Fatalf("Expected to not receive an error on Publish after drain, got %v", err)
 	}
 
 	// Wait for the closed state from nc
@@ -310,11 +310,11 @@ func TestDrainConnection(t *testing.T) {
 		}
 		r := atomic.LoadInt32(&received)
 		if r != expected {
-			t.Fatalf("Did not receive all messages from Drain, %d vs %d\n", r, expected)
+			t.Fatalf("Did not receive all messages from Drain, %d vs %d", r, expected)
 		}
 		break
 	case <-time.After(2 * time.Second):
-		t.Fatalf("Timeout waiting for closed state for connection\n")
+		t.Fatalf("Timeout waiting for closed state for connection")
 	}
 
 	// Now make sure all responses were received.
@@ -322,11 +322,11 @@ func TestDrainConnection(t *testing.T) {
 	case <-rdone:
 		r := atomic.LoadInt32(&responses)
 		if r != expected {
-			t.Fatalf("Did not receive all responses, %d vs %d\n", r, expected)
+			t.Fatalf("Did not receive all responses, %d vs %d", r, expected)
 		}
 		break
 	case <-time.After(2 * time.Second):
-		t.Fatalf("Timeout waiting for all the responses\n")
+		t.Fatalf("Timeout waiting for all the responses")
 	}
 }
 
@@ -351,7 +351,7 @@ func TestDrainConnectionAutoUnsub(t *testing.T) {
 	url := fmt.Sprintf("nats://127.0.0.1:%d", nats.DefaultPort)
 	nc, err := nats.Connect(url, nats.ErrorHandler(errCb), nats.ClosedHandler(closed))
 	if err != nil {
-		t.Fatalf("Failed to create default connection: %v\n", err)
+		t.Fatalf("Failed to create default connection: %v", err)
 	}
 	defer nc.Close()
 
@@ -362,7 +362,7 @@ func TestDrainConnectionAutoUnsub(t *testing.T) {
 
 	})
 	if err != nil {
-		t.Fatalf("Error creating subscription; %v\n", err)
+		t.Fatalf("Error creating subscription; %v", err)
 	}
 
 	sub.AutoUnsubscribe(int(expected))
@@ -383,14 +383,14 @@ func TestDrainConnectionAutoUnsub(t *testing.T) {
 	case <-done:
 		errs := atomic.LoadInt32(&errors)
 		if errs > 0 {
-			t.Fatalf("Did not expect any errors, got %d\n", errs)
+			t.Fatalf("Did not expect any errors, got %d", errs)
 		}
 		r := atomic.LoadInt32(&received)
 		if r != expected {
-			t.Fatalf("Did not receive all messages from Drain, %d vs %d\n", r, expected)
+			t.Fatalf("Did not receive all messages from Drain, %d vs %d", r, expected)
 		}
 		break
 	case <-time.After(2 * time.Second):
-		t.Fatalf("Timeout waiting for closed state for connection\n")
+		t.Fatalf("Timeout waiting for closed state for connection")
 	}
 }

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -897,16 +897,14 @@ func TestChanSubscriberPendingLimits(t *testing.T) {
 			nc.Flush()
 
 			// Send some messages
-			go func() {
-				for i := 0; i < total; i++ {
-					if err := ncp.Publish("foo", []byte("Hello")); err != nil {
-						t.Fatalf("Unexpected error on publish: %v", err)
-					}
+			for i := 0; i < total; i++ {
+				if err := ncp.Publish("foo", []byte("Hello")); err != nil {
+					t.Fatalf("Unexpected error on publish: %v", err)
 				}
-			}()
+			}
 
 			received := 0
-			tm := time.NewTimer(5 * time.Second)
+			tm := time.NewTimer(10 * time.Second)
 			defer tm.Stop()
 
 			chk := func(ok bool) {
@@ -922,11 +920,11 @@ func TestChanSubscriberPendingLimits(t *testing.T) {
 				select {
 				case _, ok := <-ch:
 					chk(ok)
+					if received >= total {
+						return
+					}
 				case <-tm.C:
-					t.Fatalf("Timed out waiting on messages")
-				}
-				if received >= total {
-					return
+					t.Fatalf("Timed out waiting on messages for test %d, received %d", typeSubs, received)
 				}
 			}
 		}()

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -554,7 +554,7 @@ func TestAsyncErrHandler(t *testing.T) {
 			t.Fatal("Did not receive proper subscription")
 		}
 		if e != nats.ErrSlowConsumer {
-			t.Fatalf("Did not receive proper error: %v vs %v\n", e, nats.ErrSlowConsumer)
+			t.Fatalf("Did not receive proper error: %v vs %v", e, nats.ErrSlowConsumer)
 		}
 		// Suppress additional calls
 		if atomic.LoadInt64(&aeCalled) == 1 {
@@ -573,7 +573,7 @@ func TestAsyncErrHandler(t *testing.T) {
 		nc.Publish(subj, b)
 	}
 	if err := nc.Flush(); err != nil {
-		t.Fatalf("Got an error on Flush:%v\n", err)
+		t.Fatalf("Got an error on Flush:%v", err)
 	}
 
 	if e := Wait(ch); e != nil {
@@ -581,10 +581,10 @@ func TestAsyncErrHandler(t *testing.T) {
 	}
 	// Make sure dropped stats is correct.
 	if d, _ := sub.Dropped(); d != toSend-limit+1 {
-		t.Fatalf("Expected Dropped to be %d, got %d\n", toSend-limit+1, d)
+		t.Fatalf("Expected Dropped to be %d, got %d", toSend-limit+1, d)
 	}
 	if ae := atomic.LoadInt64(&aeCalled); ae != 1 {
-		t.Fatalf("Expected err handler to be called only once, got %d\n", ae)
+		t.Fatalf("Expected err handler to be called only once, got %d", ae)
 	}
 
 	sub.Unsubscribe()
@@ -601,7 +601,7 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 
 	nc, err := opts.Connect()
 	if err != nil {
-		t.Fatalf("Could not connect to server: %v\n", err)
+		t.Fatalf("Could not connect to server: %v", err)
 	}
 	defer nc.Close()
 
@@ -614,7 +614,7 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 	mch := make(chan *nats.Msg, limit)
 	sub, err := nc.ChanSubscribe(subj, mch)
 	if err != nil {
-		t.Fatalf("Could not subscribe: %v\n", err)
+		t.Fatalf("Could not subscribe: %v", err)
 	}
 	ch := make(chan bool)
 	aeCalled := int64(0)
@@ -622,7 +622,7 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 	nc.SetErrorHandler(func(c *nats.Conn, s *nats.Subscription, e error) {
 		atomic.AddInt64(&aeCalled, 1)
 		if e != nats.ErrSlowConsumer {
-			t.Fatalf("Did not receive proper error: %v vs %v\n",
+			t.Fatalf("Did not receive proper error: %v vs %v",
 				e, nats.ErrSlowConsumer)
 		}
 		// Suppress additional calls
@@ -643,10 +643,10 @@ func TestAsyncErrHandlerChanSubscription(t *testing.T) {
 	}
 	// Make sure dropped stats is correct.
 	if d, _ := sub.Dropped(); d != toSend-limit {
-		t.Fatalf("Expected Dropped to be %d, go %d\n", toSend-limit, d)
+		t.Fatalf("Expected Dropped to be %d, go %d", toSend-limit, d)
 	}
 	if ae := atomic.LoadInt64(&aeCalled); ae != 1 {
-		t.Fatalf("Expected err handler to be called once, got %d\n", ae)
+		t.Fatalf("Expected err handler to be called once, got %d", ae)
 	}
 
 	sub.Unsubscribe()
@@ -721,7 +721,7 @@ func TestAsyncSubscribersOnClose(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	seen := atomic.LoadInt32(&callbacks)
 	if seen != 1 {
-		t.Fatalf("Expected only one callback, received %d callbacks\n", seen)
+		t.Fatalf("Expected only one callback, received %d callbacks", seen)
 	}
 }
 
@@ -761,7 +761,7 @@ func TestNextMsgCallOnClosedSub(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected an error calling NextMsg() on closed subscription")
 	} else if err != nats.ErrBadSubscription {
-		t.Fatalf("Expected '%v', but got: '%v'\n", nats.ErrBadSubscription, err.Error())
+		t.Fatalf("Expected '%v', but got: '%v'", nats.ErrBadSubscription, err.Error())
 	}
 }
 
@@ -1075,7 +1075,7 @@ func TestAsyncSubscriptionPending(t *testing.T) {
 	// Test old way
 	q, _ := sub.QueuedMsgs()
 	if q != total && q != total-1 {
-		t.Fatalf("Expected %d or %d, got %d\n", total, total-1, q)
+		t.Fatalf("Expected %d or %d, got %d", total, total-1, q)
 	}
 
 	// New way, make sure the same and check bytes.
@@ -1084,10 +1084,10 @@ func TestAsyncSubscriptionPending(t *testing.T) {
 	totalSize := total * mlen
 
 	if m != total && m != total-1 {
-		t.Fatalf("Expected msgs of %d or %d, got %d\n", total, total-1, m)
+		t.Fatalf("Expected msgs of %d or %d, got %d", total, total-1, m)
 	}
 	if b != totalSize && b != totalSize-mlen {
-		t.Fatalf("Expected bytes of %d or %d, got %d\n",
+		t.Fatalf("Expected bytes of %d or %d, got %d",
 			totalSize, totalSize-mlen, b)
 	}
 
@@ -1095,21 +1095,21 @@ func TestAsyncSubscriptionPending(t *testing.T) {
 	// received, MaxPending should be >= total - 1 and <= total
 	mm, bm, _ := sub.MaxPending()
 	if mm < total-1 || mm > total {
-		t.Fatalf("Expected max msgs (%d) to be between %d and %d\n",
+		t.Fatalf("Expected max msgs (%d) to be between %d and %d",
 			mm, total-1, total)
 	}
 	if bm < totalSize-mlen || bm > totalSize {
-		t.Fatalf("Expected max bytes (%d) to be between %d and %d\n",
+		t.Fatalf("Expected max bytes (%d) to be between %d and %d",
 			bm, totalSize, totalSize-mlen)
 	}
 	// Check that clear works.
 	sub.ClearMaxPending()
 	mm, bm, _ = sub.MaxPending()
 	if mm != 0 {
-		t.Fatalf("Expected max msgs to be 0 vs %d after clearing\n", mm)
+		t.Fatalf("Expected max msgs to be 0 vs %d after clearing", mm)
 	}
 	if bm != 0 {
-		t.Fatalf("Expected max bytes to be 0 vs %d after clearing\n", bm)
+		t.Fatalf("Expected max bytes to be 0 vs %d after clearing", bm)
 	}
 
 	close(block)
@@ -1153,10 +1153,10 @@ func TestAsyncSubscriptionPendingDrain(t *testing.T) {
 
 	m, b, _ := sub.Pending()
 	if m != 0 {
-		t.Fatalf("Expected msgs of 0, got %d\n", m)
+		t.Fatalf("Expected msgs of 0, got %d", m)
 	}
 	if b != 0 {
-		t.Fatalf("Expected bytes of 0, got %d\n", b)
+		t.Fatalf("Expected bytes of 0, got %d", b)
 	}
 
 	sub.Unsubscribe()
@@ -1191,10 +1191,10 @@ func TestSyncSubscriptionPendingDrain(t *testing.T) {
 
 	m, b, _ := sub.Pending()
 	if m != 0 {
-		t.Fatalf("Expected msgs of 0, got %d\n", m)
+		t.Fatalf("Expected msgs of 0, got %d", m)
 	}
 	if b != 0 {
-		t.Fatalf("Expected bytes of 0, got %d\n", b)
+		t.Fatalf("Expected bytes of 0, got %d", b)
 	}
 
 	sub.Unsubscribe()
@@ -1224,7 +1224,7 @@ func TestSyncSubscriptionPending(t *testing.T) {
 	// Test old way
 	q, _ := sub.QueuedMsgs()
 	if q != total && q != total-1 {
-		t.Fatalf("Expected %d or %d, got %d\n", total, total-1, q)
+		t.Fatalf("Expected %d or %d, got %d", total, total-1, q)
 	}
 
 	// New way, make sure the same and check bytes.
@@ -1232,10 +1232,10 @@ func TestSyncSubscriptionPending(t *testing.T) {
 	mlen := len(msg)
 
 	if m != total {
-		t.Fatalf("Expected msgs of %d, got %d\n", total, m)
+		t.Fatalf("Expected msgs of %d, got %d", total, m)
 	}
 	if b != total*mlen {
-		t.Fatalf("Expected bytes of %d, got %d\n", total*mlen, b)
+		t.Fatalf("Expected bytes of %d, got %d", total*mlen, b)
 	}
 
 	// Now drain some down and make sure pending is correct
@@ -1244,10 +1244,10 @@ func TestSyncSubscriptionPending(t *testing.T) {
 	}
 	m, b, _ = sub.Pending()
 	if m != 1 {
-		t.Fatalf("Expected msgs of 1, got %d\n", m)
+		t.Fatalf("Expected msgs of 1, got %d", m)
 	}
 	if b != mlen {
-		t.Fatalf("Expected bytes of %d, got %d\n", mlen, b)
+		t.Fatalf("Expected bytes of %d, got %d", mlen, b)
 	}
 }
 
@@ -1428,7 +1428,7 @@ func TestSubscriptionTypes(t *testing.T) {
 	sub, _ := nc.Subscribe("foo", func(_ *nats.Msg) {})
 	defer sub.Unsubscribe()
 	if st := sub.Type(); st != nats.AsyncSubscription {
-		t.Fatalf("Expected AsyncSubscription, got %v\n", st)
+		t.Fatalf("Expected AsyncSubscription, got %v", st)
 	}
 	// Check Pending
 	if err := sub.SetPendingLimits(1, 100); err != nil {
@@ -1448,7 +1448,7 @@ func TestSubscriptionTypes(t *testing.T) {
 	sub, _ = nc.SubscribeSync("foo")
 	defer sub.Unsubscribe()
 	if st := sub.Type(); st != nats.SyncSubscription {
-		t.Fatalf("Expected SyncSubscription, got %v\n", st)
+		t.Fatalf("Expected SyncSubscription, got %v", st)
 	}
 	// Check Pending
 	if err := sub.SetPendingLimits(1, 100); err != nil {
@@ -1468,7 +1468,7 @@ func TestSubscriptionTypes(t *testing.T) {
 	sub, _ = nc.ChanSubscribe("foo", make(chan *nats.Msg))
 	defer sub.Unsubscribe()
 	if st := sub.Type(); st != nats.ChanSubscription {
-		t.Fatalf("Expected ChanSubscription, got %v\n", st)
+		t.Fatalf("Expected ChanSubscription, got %v", st)
 	}
 	// Check Pending
 	if err := sub.SetPendingLimits(1, 100); err == nil {

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -580,11 +580,11 @@ func TestAsyncErrHandler(t *testing.T) {
 		t.Fatal("Failed to call async err handler")
 	}
 	// Make sure dropped stats is correct.
-	if d, _ := sub.Dropped(); d != toSend-limit {
-		t.Fatalf("Expected Dropped to be %d, got %d\n", toSend-limit, d)
+	if d, _ := sub.Dropped(); d != toSend-limit+1 {
+		t.Fatalf("Expected Dropped to be %d, got %d\n", toSend-limit+1, d)
 	}
 	if ae := atomic.LoadInt64(&aeCalled); ae != 1 {
-		t.Fatalf("Expected err handler to be called once, got %d\n", ae)
+		t.Fatalf("Expected err handler to be called only once, got %d\n", ae)
 	}
 
 	sub.Unsubscribe()


### PR DESCRIPTION
This PR allows clients to drain subscriptions or complete connections. This allows for graceful shutdown of clients, especially queue subscribers.

on a connection drain, any errors will fire the asyncErrCB. When all publish messages have been flushed and all subscriptions drained properly the connection will move to a closed state.