### PR TITLE
Allow nil options

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -435,8 +435,10 @@ func Connect(url string, options ...Option) (*Conn, error) {
 	opts := GetDefaultOptions()
 	opts.Servers = processUrlString(url)
 	for _, opt := range options {
-		if err := opt(&opts); err != nil {
-			return nil, err
+		if opt != nil {
+			if err := opt(&opts); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return opts.Connect()

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1977,7 +1977,7 @@ func TestNilOpts(t *testing.T) {
 	o2 = nats.ReconnectBufSize(2222)
 	nc, err = nats.Connect(nats.DefaultURL, o1, o2, o3)
 	if err != nil {
-		t.Fatalf("Unexpected error with muliple nil options: %v", err)
+		t.Fatalf("Unexpected error with multiple nil options: %v", err)
 	}
 	// check that the opt was set
 	if nc.Opts.ReconnectBufSize != 2222 {

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1961,3 +1961,26 @@ func TestReceiveInfoWithEmptyConnectURLs(t *testing.T) {
 	nc.Close()
 	wg.Wait()
 }
+
+func TestNilOpts(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	// Test a single nil option
+	var o1, o2, o3 nats.Option
+	nc, err := nats.Connect(nats.DefaultURL, o1)
+	if err != nil {
+		t.Fatalf("Unexpected error with one nil option: %v", err)
+	}
+
+	// Test nil, opt, nil
+	o2 = nats.ReconnectBufSize(2222)
+	nc, err = nats.Connect(nats.DefaultURL, o1, o2, o3)
+	if err != nil {
+		t.Fatalf("Unexpected error with muliple nil options: %v", err)
+	}
+	// check that the opt was set
+	if nc.Opts.ReconnectBufSize != 2222 {
+		t.Fatal("Unexpected error: option not set.")
+	}
+}


### PR DESCRIPTION
Users may want to setup a pattern using potentially nil options. 

An example would be:

```go
var ca, cert nats.Option

if (cafile != "") {
    ca = nats.RootCAs(cafile)
}
if (certfile != "") {
   cert = nats.ClientCert(certfile, keyfile)
}

nc, err := nats.Connect("nats://myhost:4222", ca, cert)
```

This results in a fault if an option isn't set, e.g. if a CA wasn't used.  This change would would allow this pattern.

Signed-off-by: Colin Sullivan <colin@synadia.com>