### PR TITLE
Allow nil options in the nats.Connect API

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -465,8 +465,10 @@ func Connect(url string, options ...Option) (*Conn, error) {
 	opts := GetDefaultOptions()
 	opts.Servers = processUrlString(url)
 	for _, opt := range options {
-		if err := opt(&opts); err != nil {
-			return nil, err
+		if opt != nil {
+			if err := opt(&opts); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return opts.Connect()

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -2028,3 +2028,26 @@ func TestConnectWithSimplifiedURLs(t *testing.T) {
 		connect(t, u)
 	}
 }
+
+func TestNilOpts(t *testing.T) {
+	s := RunDefaultServer()
+	defer s.Shutdown()
+
+	// Test a single nil option
+	var o1, o2, o3 nats.Option
+	nc, err := nats.Connect(nats.DefaultURL, o1)
+	if err != nil {
+		t.Fatalf("Unexpected error with one nil option: %v", err)
+	}
+
+	// Test nil, opt, nil
+	o2 = nats.ReconnectBufSize(2222)
+	nc, err = nats.Connect(nats.DefaultURL, o1, o2, o3)
+	if err != nil {
+		t.Fatalf("Unexpected error with multiple nil options: %v", err)
+	}
+	// check that the opt was set
+	if nc.Opts.ReconnectBufSize != 2222 {
+		t.Fatal("Unexpected error: option not set.")
+	}
+}

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -2035,14 +2035,14 @@ func TestNilOpts(t *testing.T) {
 
 	// Test a single nil option
 	var o1, o2, o3 nats.Option
-	nc, err := nats.Connect(nats.DefaultURL, o1)
+	_, err := nats.Connect(nats.DefaultURL, o1)
 	if err != nil {
 		t.Fatalf("Unexpected error with one nil option: %v", err)
 	}
 
 	// Test nil, opt, nil
 	o2 = nats.ReconnectBufSize(2222)
-	nc, err = nats.Connect(nats.DefaultURL, o1, o2, o3)
+	nc, err := nats.Connect(nats.DefaultURL, o1, o2, o3)
 	if err != nil {
 		t.Fatalf("Unexpected error with multiple nil options: %v", err)
 	}


### PR DESCRIPTION
Users may want to setup a pattern using options that could be nil. 

An example would be:

```go
var ca, cert nats.Option

if (cafile != "") {
    ca = nats.RootCAs(cafile)
}
if (certfile != "") {
   cert = nats.ClientCert(certfile, keyfile)
}

nc, err := nats.Connect("nats://myhost:4222", ca, cert)
```

Today this would result in a fault if an option isn't set, e.g. if a CA wasn't used.  This PR allows this pattern.

Signed-off-by: Colin Sullivan <colin@synadia.com>