### PR TITLE
[FIXED] Request or NextMsg with Context may return message after being canceled

### DIFF
--- a/context.go
+++ b/context.go
@@ -31,6 +31,13 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 	if nc == nil {
 		return nil, ErrInvalidConnection
 	}
+	// Check whether the context is done already before making
+	// the request.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	nc.mu.Lock()
 	// If user wants the old style.
@@ -116,6 +123,11 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	if s == nil {
 		return nil, ErrBadSubscription
 	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	s.mu.Lock()
 	err := s.validateNextMsgState()
@@ -124,7 +136,6 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 		return nil, err
 	}
 
-	// snapshot
 	mch := s.mch
 	s.mu.Unlock()
 

--- a/context.go
+++ b/context.go
@@ -33,10 +33,8 @@ func (nc *Conn) RequestWithContext(ctx context.Context, subj string, data []byte
 	}
 	// Check whether the context is done already before making
 	// the request.
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return nil, ctx.Err()
-	default:
 	}
 
 	nc.mu.Lock()
@@ -123,10 +121,8 @@ func (s *Subscription) NextMsgWithContext(ctx context.Context) (*Msg, error) {
 	if s == nil {
 		return nil, ErrBadSubscription
 	}
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return nil, ctx.Err()
-	default:
 	}
 
 	s.mu.Lock()

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -17,7 +17,6 @@ package test
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -136,16 +135,6 @@ func testContextRequestWithTimeoutCanceled(t *testing.T, nc *nats.Conn) {
 
 	// Cancel the context already so that rest of requests fail.
 	cancelCB()
-
-	// Wait for context to be eventually canceled.
-	waitFor(t, 1*time.Millisecond, 50*time.Millisecond, func() error {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			return errors.New("Timeout waiting for context to be canceled")
-		}
-	})
 
 	// Context is already canceled so requests should immediately fail.
 	_, err = nc.RequestWithContext(ctx, "fast", []byte("world"))


### PR DESCRIPTION
Currently behavior of context in the client is not deterministic when the context has already been canceled and is possible for a client to still receive messages from a request, as shown in the test occasionally failing in Travis:

```
--- FAIL: TestOldContextRequestWithTimeout (0.13s)
    context_test.go:91: Expected request with context to fail
```

In order to fix this, now we check first whether the context has been canceled already previous to waiting for the message to prevent successfully making requests using an invalid context.
