### PR TITLE
Support for User JWTs

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1425,9 +1425,8 @@ func (nc *Conn) connectProto() (string, error) {
 		token = nc.Opts.TokenHandler()
 	}
 
-	cinfo := connectInfo{o.Verbose, o.Pedantic, string(ujwt),
-		nkey, sig, user, pass, token, o.Secure, o.Name, LangString,
-		Version, clientProtoInfo, !o.NoEcho}
+	cinfo := connectInfo{o.Verbose, o.Pedantic, ujwt, nkey, sig, user, pass, token,
+		o.Secure, o.Name, LangString, Version, clientProtoInfo, !o.NoEcho}
 
 	b, err := json.Marshal(cinfo)
 	if err != nil {


### PR DESCRIPTION
This adds support for a user JWT. This adds to bare nkey support.

We support this as a callback to support JWT upgrades while an application is running.

We support decorated formats as provided by nsc, and we support chained files that have the user JWT and the user seed in the same file.

Signed-off-by: Derek Collison <derek@nats.io>
