### PR TITLE
[FIXED] Maintain string case in errors

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1529,7 +1529,7 @@ func (nc *Conn) connectProto() (string, error) {
 
 // normalizeErr removes the prefix -ERR, trim spaces and remove the quotes.
 func normalizeErr(line string) string {
-	s := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(line, _ERR_OP_)))
+	s := strings.TrimSpace(strings.TrimPrefix(line, _ERR_OP_))
 	s = strings.TrimLeft(strings.TrimRight(s, "'"), "'")
 	return s
 }
@@ -2342,20 +2342,22 @@ func (nc *Conn) LastError() error {
 
 // processErr processes any error messages from the server and
 // sets the connection's lastError.
-func (nc *Conn) processErr(e string) {
-	// Trim, remove quotes, convert to lower case.
-	e = normalizeErr(e)
+func (nc *Conn) processErr(ie string) {
+	// Trim, remove quotes
+	ne := normalizeErr(ie)
+	// convert to lower case.
+	e := strings.ToLower(ne)
 
 	// FIXME(dlc) - process Slow Consumer signals special.
 	if e == STALE_CONNECTION {
 		nc.processOpErr(ErrStaleConnection)
 	} else if strings.HasPrefix(e, PERMISSIONS_ERR) {
-		nc.processPermissionsViolation(e)
+		nc.processPermissionsViolation(ne)
 	} else if strings.HasPrefix(e, AUTHORIZATION_ERR) {
-		nc.processAuthorizationViolation(e)
+		nc.processAuthorizationViolation(ne)
 	} else {
 		nc.mu.Lock()
-		nc.err = errors.New("nats: " + e)
+		nc.err = errors.New("nats: " + ne)
 		nc.mu.Unlock()
 		nc.Close()
 	}

--- a/nats_test.go
+++ b/nats_test.go
@@ -882,39 +882,33 @@ func TestParserSplitMsg(t *testing.T) {
 }
 
 func TestNormalizeError(t *testing.T) {
-	received := "Typical Error"
-	expected := strings.ToLower(received)
-	if s := normalizeErr("-ERR '" + received + "'"); s != expected {
+	expected := "Typical Error"
+	if s := normalizeErr("-ERR '" + expected + "'"); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 
-	received = "Trim Surrounding Spaces"
-	expected = strings.ToLower(received)
-	if s := normalizeErr("-ERR    '" + received + "'   "); s != expected {
+	expected = "Trim Surrounding Spaces"
+	if s := normalizeErr("-ERR    '" + expected + "'   "); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 
-	received = "Trim Surrounding Spaces Without Quotes"
-	expected = strings.ToLower(received)
-	if s := normalizeErr("-ERR    " + received + "   "); s != expected {
+	expected = "Trim Surrounding Spaces Without Quotes"
+	if s := normalizeErr("-ERR    " + expected + "   "); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 
-	received = "Error Without Quotes"
-	expected = strings.ToLower(received)
-	if s := normalizeErr("-ERR " + received); s != expected {
+	expected = "Error Without Quotes"
+	if s := normalizeErr("-ERR " + expected); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 
-	received = "Error With Quote Only On Left"
-	expected = strings.ToLower(received)
-	if s := normalizeErr("-ERR '" + received); s != expected {
+	expected = "Error With Quote Only On Left"
+	if s := normalizeErr("-ERR '" + expected); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 
-	received = "Error With Quote Only On Right"
-	expected = strings.ToLower(received)
-	if s := normalizeErr("-ERR " + received + "'"); s != expected {
+	expected = "Error With Quote Only On Right"
+	if s := normalizeErr("-ERR " + expected + "'"); s != expected {
 		t.Fatalf("Expected '%s', got '%s'", expected, s)
 	}
 }

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -167,7 +167,7 @@ func TestAuthServers(t *testing.T) {
 		t.Fatalf("Expect Auth failure, got no error\n")
 	}
 
-	if !strings.Contains(err.Error(), "authorization") {
+	if !strings.Contains(err.Error(), "Authorization") {
 		t.Fatalf("Wrong error, wanted Auth failure, got '%s'\n", err)
 	}
 

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -1235,7 +1235,7 @@ func TestServerErrorClosesConnection(t *testing.T) {
 
 	// Check LastError(), it should be "nats: <server error in lower case>"
 	lastErr := nc.LastError().Error()
-	expectedErr := "nats: " + strings.ToLower(serverSentError)
+	expectedErr := "nats: " + serverSentError
 	if lastErr != expectedErr {
 		t.Fatalf("Expected error: '%v', got '%v'", expectedErr, lastErr)
 	}


### PR DESCRIPTION
A permission error on a subject that would have upper case would
be converted to all lower case, which is not correct.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>