### PR TITLE
[CHANGED] Don't skip TLS hostname verification

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -1229,14 +1229,12 @@ func (nc *Conn) createConn() (err error) {
 
 // makeTLSConn will wrap an existing Conn using TLS
 func (nc *Conn) makeTLSConn() error {
-	// Allow the user to configure their own tls.Config structure,
-	// otherwise default to InsecureSkipVerify.
-	// TODO(dlc) - We should make the more secure version the default.
+	// Allow the user to configure their own tls.Config structure.
 	var tlsCopy *tls.Config
 	if nc.Opts.TLSConfig != nil {
 		tlsCopy = util.CloneTLSConfig(nc.Opts.TLSConfig)
 	} else {
-		tlsCopy = &tls.Config{InsecureSkipVerify: true}
+		tlsCopy = &tls.Config{}
 	}
 	// If its blank we will override it with the current host
 	if tlsCopy.ServerName == _EMPTY_ {


### PR DESCRIPTION
If given URL is `nats://...` and the client connects to a server
that requires TLS, the library would automatically switch but
skip hostname verification.
This PR changes this behavior and by default will verify server
hostname. User will have to provide their own TLSConfig if
skipping is desired.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>