### PR TITLE
Fix error in reconnect handler docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ nc, err = nats.Connect(servers,
 	nats.DisconnectHandler(func(nc *nats.Conn) {
 		fmt.Printf("Got disconnected!\n")
 	}),
-	nats.ReconnectHandler(func(_ *nats.Conn) {
+	nats.ReconnectHandler(func(nc *nats.Conn) {
 		fmt.Printf("Got reconnected to %v!\n", nc.ConnectedUrl())
 	}),
 	nats.ClosedHandler(func(nc *nats.Conn) {


### PR DESCRIPTION
In the following code:

```
	nats.ReconnectHandler(func(_ *nats.Conn) {
		fmt.Printf("Got reconnected to %v!\n", nc.ConnectedUrl())
	}),
```

We're trying to access `nc.ConnectedUrl()` but we're taking the argument of `*nats.Conn` as `_` instead of `nc`