### PR TITLE
Replace megacheck with staticcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,18 @@ sudo: false
 go:
 - 1.11.x
 - 1.10.x
-- 1.9.x
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
-- go get -u honnef.co/go/tools/cmd/megacheck
+- go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
 - $(exit $(go fmt ./... | wc -l))
 - go vet ./...
 - misspell -error -locale US .
-- megacheck -ignore "$(cat staticcheck.ignore)" ./...
+- staticcheck -ignore "$(cat staticcheck.ignore)" ./...
 script:
 - go test -i -race ./...
 - if [[ "$TRAVIS_GO_VERSION" =~ 1.11 ]]; then ./scripts/cov.sh TRAVIS; else go test -race ./...; fi

--- a/enc.go
+++ b/enc.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	// Default Encoders
-	. "github.com/nats-io/go-nats/encoders/builtin"
+	"github.com/nats-io/go-nats/encoders/builtin"
 )
 
 // Encoder interface is for all register encoders
@@ -43,9 +43,9 @@ const (
 func init() {
 	encMap = make(map[string]Encoder)
 	// Register json, gob and default encoder
-	RegisterEncoder(JSON_ENCODER, &JsonEncoder{})
-	RegisterEncoder(GOB_ENCODER, &GobEncoder{})
-	RegisterEncoder(DEFAULT_ENCODER, &DefaultEncoder{})
+	RegisterEncoder(JSON_ENCODER, &builtin.JsonEncoder{})
+	RegisterEncoder(GOB_ENCODER, &builtin.GobEncoder{})
+	RegisterEncoder(DEFAULT_ENCODER, &builtin.DefaultEncoder{})
 }
 
 // EncodedConn are the preferred way to interface with NATS. They wrap a bare connection to
@@ -67,7 +67,7 @@ func NewEncodedConn(c *Conn, encType string) (*EncodedConn, error) {
 	}
 	ec := &EncodedConn{Conn: c, Enc: EncoderForType(encType)}
 	if ec.Enc == nil {
-		return nil, fmt.Errorf("No encoder registered for '%s'", encType)
+		return nil, fmt.Errorf("no encoder registered for '%s'", encType)
 	}
 	return ec, nil
 }

--- a/test/netchan_test.go
+++ b/test/netchan_test.go
@@ -251,7 +251,7 @@ func TestRecvChanAsyncLeakGoRoutines(t *testing.T) {
 	// Call this to make sure that we have everything setup connection wise
 	ec.Flush()
 
-	before := runtime.NumGoroutine()
+	before := getStableNumGoroutine(t)
 
 	ch := make(chan int)
 
@@ -285,7 +285,7 @@ func TestRecvChanLeakGoRoutines(t *testing.T) {
 	// Call this to make sure that we have everything setup connection wise
 	ec.Flush()
 
-	before := runtime.NumGoroutine()
+	before := getStableNumGoroutine(t)
 
 	ch := make(chan int)
 

--- a/test/sub_test.go
+++ b/test/sub_test.go
@@ -38,7 +38,7 @@ func TestServerAutoUnsub(t *testing.T) {
 	// Call this to make sure that we have everything setup connection wise
 	nc.Flush()
 
-	base := runtime.NumGoroutine()
+	base := getStableNumGoroutine(t)
 
 	sub, err := nc.Subscribe("foo", func(_ *nats.Msg) {
 		atomic.AddInt32(&received, 1)


### PR DESCRIPTION
Megacheck has been deprecated.
Dropping Go 1.9 from build matrix since staticcheck does not work
with that and Go 1.9 is technically no longer supported.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>