### PR TITLE
Add go import path to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 go:
 - 1.11.x
 - 1.10.x
+go_import_path: github.com/nats-io/go-nats
 install:
 - go get -t ./...
 - go get github.com/nats-io/gnatsd


### PR DESCRIPTION
Similar to https://github.com/nats-io/gnatsd/pull/906 , nice to have to be able to run the build on Travis on a forked repo
Signed-off-by: Waldemar Quevedo <wally@synadia.com>