### PR TITLE
Change flushChanSize from 1024 to 1.

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -330,7 +330,7 @@ const (
 	defaultBufSize = 32768
 
 	// The buffered size of the flush "kick" channel
-	flushChanSize = 1024
+	flushChanSize = 1
 
 	// Default server pool size
 	srvPoolSize = 4


### PR DESCRIPTION
#436  Change flushChanSize from 1024 to 1.
And `fch` is already non block style.
https://github.com/nats-io/go-nats/blob/master/nats.go#L2394
https://github.com/nats-io/go-nats/blob/master/nats.go#L1272