### PR TITLE
Add option to trigger handlers in a separate go routines so they can …

### DIFF
--- a/enc.go
+++ b/enc.go
@@ -171,18 +171,32 @@ var emptyMsgType = reflect.TypeOf(&Msg{})
 // messages using the specified Handler. The Handler should be a func that matches
 // a signature from the description of Handler from above.
 func (c *EncodedConn) Subscribe(subject string, cb Handler) (*Subscription, error) {
-	return c.subscribe(subject, _EMPTY_, cb)
+	return c.subscribe(subject, _EMPTY_, cb, false)
 }
 
 // QueueSubscribe will create a queue subscription on the given subject and process
 // incoming messages using the specified Handler. The Handler should be a func that
 // matches a signature from the description of Handler from above.
 func (c *EncodedConn) QueueSubscribe(subject, queue string, cb Handler) (*Subscription, error) {
-	return c.subscribe(subject, queue, cb)
+	return c.subscribe(subject, queue, cb, false)
+}
+
+// This is very similar to Subscribe
+// the main difference is this will invoke handler in the separate go routine
+// Use this if you require parallel processing of the incoming messages
+func (c *EncodedConn) SubscribeParallel(subject string, cb Handler) (*Subscription, error) {
+	return c.subscribe(subject, _EMPTY_, cb, true)
+}
+
+// This is very similar to QueueSubscribe
+// the main difference is this will invoke handler in the separate go routine
+// Use this if you require parallel processing of the incoming messages
+func (c *EncodedConn) QueueSubscribeParallel(subject, queue string, cb Handler) (*Subscription, error) {
+	return c.subscribe(subject, queue, cb, true)
 }
 
 // Internal implementation that all public functions will use.
-func (c *EncodedConn) subscribe(subject, queue string, cb Handler) (*Subscription, error) {
+func (c *EncodedConn) subscribe(subject, queue string, cb Handler, isParallel bool) (*Subscription, error) {
 	if cb == nil {
 		return nil, errors.New("nats: Handler required for EncodedConn Subscription")
 	}
@@ -231,7 +245,11 @@ func (c *EncodedConn) subscribe(subject, queue string, cb Handler) (*Subscriptio
 			}
 
 		}
-		cbValue.Call(oV)
+		if isParallel {
+			go cbValue.Call(oV)
+		} else {
+			cbValue.Call(oV)
+		}
 	}
 
 	return c.Conn.subscribe(subject, queue, natsCB, nil, false)

--- a/test/enc_test.go
+++ b/test/enc_test.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -466,5 +467,93 @@ func TestEncDrainSupported(t *testing.T) {
 	err := ec.Drain()
 	if err != nil {
 		t.Fatalf("Expected no error calling Drain(), got %v", err)
+	}
+}
+
+func TestEncSubscribeParallel(t *testing.T) {
+	s := RunServerOnPort(TEST_PORT)
+	defer s.Shutdown()
+
+	ec := NewDefaultEConn(t)
+	defer ec.Close()
+
+	ch := make(chan bool)
+
+	oSubj := "parallel"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	receivedA := false
+	receivedB := false
+
+	ec.SubscribeParallel(oSubj, func(s string) {
+		switch s {
+		case "messageA":
+			receivedA = true
+		case "messageB":
+			receivedB = true
+		}
+		wg.Done()
+		wg.Wait()
+		ch <- true
+	})
+	ec.Publish(oSubj, "messageA")
+	ec.Publish(oSubj, "messageB")
+	if e := Wait(ch); e != nil {
+		if ec.LastError() != nil {
+			e = ec.LastError()
+		}
+		t.Fatalf("Did not receive the message: %s", e)
+	}
+
+	if !receivedA {
+		t.Fatal("Didn't receive message with value 'messageA'")
+	}
+	if !receivedB {
+		t.Fatal("Didn't receive message with value 'messageB'")
+	}
+}
+
+func TestEncQueueSubscribeParallel(t *testing.T) {
+	s := RunServerOnPort(TEST_PORT)
+	defer s.Shutdown()
+
+	ec := NewDefaultEConn(t)
+	defer ec.Close()
+
+	ch := make(chan bool)
+
+	oSubj := "parallel"
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	receivedA := false
+	receivedB := false
+
+	ec.QueueSubscribeParallel(oSubj, "parallel", func(s string) {
+		switch s {
+		case "messageA":
+			receivedA = true
+		case "messageB":
+			receivedB = true
+		}
+		wg.Done()
+		wg.Wait()
+		ch <- true
+	})
+	ec.Publish(oSubj, "messageA")
+	ec.Publish(oSubj, "messageB")
+	if e := Wait(ch); e != nil {
+		if ec.LastError() != nil {
+			e = ec.LastError()
+		}
+		t.Fatalf("Did not receive the message: %s", e)
+	}
+
+	if !receivedA {
+		t.Fatal("Didn't receive message with value 'messageA'")
+	}
+	if !receivedB {
+		t.Fatal("Didn't receive message with value 'messageB'")
 	}
 }


### PR DESCRIPTION
Subscribe and QueueSubscribe are running in the serial way. This PR adds option to run them in the parallel mode.

This relates to https://github.com/nats-io/go-nats/issues/263

This addition is only for enc connection.