### PR TITLE
Exit after usage

### DIFF
--- a/examples/nats-bench/main.go
+++ b/examples/nats-bench/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"sync"
 	"time"
 
@@ -36,6 +37,7 @@ const (
 func usage() {
 	log.Printf("Usage: nats-bench [-s server (%s)] [--tls] [-np NUM_PUBLISHERS] [-ns NUM_SUBSCRIBERS] [-n NUM_MSGS] [-ms MESSAGE_SIZE] [-csv csvfile] <subject>\n", nats.DefaultURL)
 	flag.PrintDefaults()
+	os.Exit(1)
 }
 
 var benchmark *bench.Benchmark


### PR DESCRIPTION
Recent changes removed a `Fatalf` in `usage`, which exited with an `os.Exit(1)`.  With this change when the benchmark was launched without the proper number of parameters, it would continue execution after `usage` and panic.

Add `os.Exit(1)` at the end of `usage` to restore previous exit behavior.

Signed-off-by: Colin Sullivan <colin@synadia.com>