### PR TITLE
[CHANGED] DefaultURL changed to "nats://127.0.0.1:4222"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 go_import_path: github.com/nats-io/go-nats
 install:
 - go get -t ./...
-- go get github.com/nats-io/gnatsd
+- go get github.com/nats-io/nats-server
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 - go get -u honnef.co/go/tools/cmd/staticcheck

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/go-nats
 
 # Server
-go get github.com/nats-io/gnatsd
+go get github.com/nats-io/nats-server
 ```
 
 ## Basic Usage

--- a/nats.go
+++ b/nats.go
@@ -44,7 +44,7 @@ import (
 // Default Constants
 const (
 	Version                 = "1.7.2"
-	DefaultURL              = "nats://localhost:4222"
+	DefaultURL              = "nats://127.0.0.1:4222"
 	DefaultPort             = 4222
 	DefaultMaxReconnect     = 60
 	DefaultReconnectWait    = 2 * time.Second

--- a/nats_test.go
+++ b/nats_test.go
@@ -36,8 +36,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
-	gnatsd "github.com/nats-io/gnatsd/test"
+	"github.com/nats-io/nats-server/server"
+	natsserver "github.com/nats-io/nats-server/test"
 	"github.com/nats-io/nkeys"
 )
 
@@ -112,13 +112,13 @@ var reconnectOpts = Options{
 }
 
 func RunServerOnPort(port int) *server.Server {
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Port = port
 	return RunServerWithOptions(&opts)
 }
 
 func RunServerWithOptions(opts *server.Options) *server.Server {
-	return gnatsd.RunServer(opts)
+	return natsserver.RunServer(opts)
 }
 
 func TestReconnectServerStats(t *testing.T) {
@@ -1045,16 +1045,16 @@ func TestAsyncINFO(t *testing.T) {
 	if err != nil || c.ps.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
-	// Pool now should contain localhost:4222 (the default URL) and localhost:5222
-	checkPool("localhost:4222", "localhost:5222")
+	// Pool now should contain 127.0.0.1:4222 (the default URL), localhost:4222 and localhost:5222
+	checkPool("127.0.0.1:4222", "localhost:4222", "localhost:5222")
 
 	// Make sure that if client receives the same, it is not added again.
 	err = c.parse(info)
 	if err != nil || c.ps.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
-	// Pool should still contain localhost:4222 (the default URL) and localhost:5222
-	checkPool("localhost:4222", "localhost:5222")
+	// Pool should still contain 127.0.0.1:4222 (the default URL), localhost:4222 and localhost:5222
+	checkPool("127.0.0.1:4222", "localhost:4222", "localhost:5222")
 
 	// Receive a new URL
 	info = []byte("INFO {\"connect_urls\":[\"localhost:4222\", \"localhost:5222\", \"localhost:6222\"]}\r\n")
@@ -1062,8 +1062,8 @@ func TestAsyncINFO(t *testing.T) {
 	if err != nil || c.ps.state != OP_START {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
-	// Pool now should contain localhost:4222 (the default URL) localhost:5222 and localhost:6222
-	checkPool("localhost:4222", "localhost:5222", "localhost:6222")
+	// Pool now should contain 127.0.0.1:4222 (the default URL), localhost:4222, localhost:5222 and localhost:6222
+	checkPool("127.0.0.1:4222", "localhost:4222", "localhost:5222", "localhost:6222")
 
 	// Check that pool may be randomized on setup, but new URLs are always
 	// added at end of pool.
@@ -1130,7 +1130,7 @@ func TestConnServers(t *testing.T) {
 	}
 
 	// check the default url
-	validateURLs(c.Servers(), "nats://localhost:4222")
+	validateURLs(c.Servers(), "nats://127.0.0.1:4222")
 	if len(c.DiscoveredServers()) != 0 {
 		t.Fatalf("Expected no discovered servers")
 	}
@@ -1141,7 +1141,7 @@ func TestConnServers(t *testing.T) {
 		t.Fatalf("Unexpected: %d : %v\n", c.ps.state, err)
 	}
 	// Server list should now contain both the default and the new url.
-	validateURLs(c.Servers(), "nats://localhost:4222", "nats://localhost:5222")
+	validateURLs(c.Servers(), "nats://127.0.0.1:4222", "nats://localhost:5222")
 	// Discovered servers should only contain the new url.
 	validateURLs(c.DiscoveredServers(), "nats://localhost:5222")
 
@@ -1302,7 +1302,7 @@ SUAMK2FG4MI6UE3ACF3FK3OIQBCEIEZV7NSWFFEW63UXMRLFM2XLAXK4GY
 func runTrustServer() *server.Server {
 	kp, _ := nkeys.FromSeed(oSeed)
 	pub, _ := kp.PublicKey()
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Port = TEST_PORT
 	opts.TrustedKeys = []string{string(pub)}
 	s := RunServerWithOptions(&opts)
@@ -1407,7 +1407,7 @@ func TestUserCredentialsChainedFileNotFoundError(t *testing.T) {
 	// Setup opts for both servers.
 	kp, _ := nkeys.FromSeed(oSeed)
 	pub, _ := kp.PublicKey()
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Port = -1
 	opts.Cluster.Port = -1
 	opts.TrustedKeys = []string{string(pub)}
@@ -1466,7 +1466,7 @@ func TestNkeyAuth(t *testing.T) {
 	kp, _ := nkeys.FromSeed(seed)
 	pub, _ := kp.PublicKey()
 
-	sopts := gnatsd.DefaultTestOptions
+	sopts := natsserver.DefaultTestOptions
 	sopts.Port = TEST_PORT
 	sopts.Nkeys = []*server.NkeyUser{&server.NkeyUser{Nkey: string(pub)}}
 	ts := RunServerWithOptions(&sopts)
@@ -1633,7 +1633,7 @@ func TestLookupHostResultIsRandomized(t *testing.T) {
 		t.Skip("Was looking for IPv4 and IPv6 addresses for localhost to perform test")
 	}
 
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Host = "127.0.0.1"
 	opts.Port = TEST_PORT
 	s1 := RunServerWithOptions(&opts)
@@ -1667,7 +1667,7 @@ func TestLookupHostResultIsNotRandomizedWithNoRandom(t *testing.T) {
 		t.Skip("Was looking for IPv4 and IPv6 addresses for localhost to perform test")
 	}
 
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Host = orgAddrs[0]
 	opts.Port = TEST_PORT
 	s1 := RunServerWithOptions(&opts)

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats-server/test"
 )
 
 func TestAuth(t *testing.T) {

--- a/test/cluster_test.go
+++ b/test/cluster_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats-server/test"
 )
 
 var testServers = []string{

--- a/test/conn_test.go
+++ b/test/conn_test.go
@@ -29,9 +29,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/gnatsd/test"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
+	"github.com/nats-io/nats-server/test"
 )
 
 func TestDefaultConnection(t *testing.T) {

--- a/test/helper_test.go
+++ b/test/helper_test.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
 
-	gnatsd "github.com/nats-io/gnatsd/test"
+	natsserver "github.com/nats-io/nats-server/test"
 )
 
 // So that we can pass tests and benchmarks...
@@ -78,7 +78,7 @@ func NewDefaultConnection(t tLogger) *nats.Conn {
 
 // NewConnection forms connection on a given port.
 func NewConnection(t tLogger, port int) *nats.Conn {
-	url := fmt.Sprintf("nats://localhost:%d", port)
+	url := fmt.Sprintf("nats://127.0.0.1:%d", port)
 	nc, err := nats.Connect(url)
 	if err != nil {
 		t.Fatalf("Failed to create default connection: %v\n", err)
@@ -97,7 +97,7 @@ func NewEConn(t tLogger) *nats.EncodedConn {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Running gnatsd server in separate Go routines
+// Running nats server in separate Go routines
 ////////////////////////////////////////////////////////////////////////////////
 
 // RunDefaultServer will run a server on the default port.
@@ -107,17 +107,17 @@ func RunDefaultServer() *server.Server {
 
 // RunServerOnPort will run a server on the given port.
 func RunServerOnPort(port int) *server.Server {
-	opts := gnatsd.DefaultTestOptions
+	opts := natsserver.DefaultTestOptions
 	opts.Port = port
 	return RunServerWithOptions(opts)
 }
 
 // RunServerWithOptions will run a server with the given options.
 func RunServerWithOptions(opts server.Options) *server.Server {
-	return gnatsd.RunServer(&opts)
+	return natsserver.RunServer(&opts)
 }
 
 // RunServerWithConfig will run a server with the given configuration file.
 func RunServerWithConfig(configFile string) (*server.Server, *server.Options) {
-	return gnatsd.RunServerWithConfig(configFile)
+	return natsserver.RunServerWithConfig(configFile)
 }

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
 	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/server"
 )
 
 func startReconnectServer(t *testing.T) *server.Server {


### PR DESCRIPTION
Replaced to loopback ipv4 instead of localhost. In some cases,
when running the server with 127.0.0.1, if the application uses
the previous default URL (localhost), the library would resolve
this and possibly get 2 IPs (common to get 127.0.0.1 and ::1),
and it would then pick randomly one of those 2. If getting ::1,
and the server is listening on 127.0.0.1, the connection would
fail before it tries with the ipv4 address.

Also replaced reference of gnatsd with nats-server.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>